### PR TITLE
Hardcoded "div" and "mod"

### DIFF
--- a/src/AST.purs
+++ b/src/AST.purs
@@ -9,7 +9,7 @@ import Data.List (List)
 -- | (`Colon` is `Cons` but clashes with `Data.List.Cons`)
 data Op = Composition
         | Power
-        | Mul | Div | Mod
+        | Mul
         | Add | Sub
         | Colon | Append
         | Equ | Neq | Lt | Leq | Gt | Geq
@@ -159,8 +159,6 @@ instance showOp :: Show Op where
     Composition -> "Composition"
     Power  -> "Power"
     Mul    -> "Mul"
-    Div    -> "Div"
-    Mod    -> "Mod"
     Add    -> "Add"
     Sub    -> "Sub"
     Colon  -> "Colon"
@@ -181,8 +179,6 @@ pPrintOp op = case op of
   Composition -> "."
   Power  -> "^"
   Mul    -> "*"
-  Div    -> "`div`"
-  Mod    -> "`mod`"
   Add    -> "+"
   Sub    -> "-"
   Colon  -> ":"

--- a/src/TypeChecker.purs
+++ b/src/TypeChecker.purs
@@ -259,9 +259,12 @@ inferType env exp = do
 infer :: TypeEnv -> Expr -> Infer (Tuple Subst TypeTree)
 infer env ex = case ex of
 
-  (Atom x@(Name _)) -> do
-    Tuple s t <- lookupEnv env x
-    return (Tuple s $ TAtom t)
+  (Atom x@(Name n)) -> case n of
+    "mod" -> return $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
+    "div" -> return $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
+    _     -> do
+      Tuple s t <- lookupEnv env x
+      return (Tuple s $ TAtom t)
   (Atom (Bool _)) -> return (Tuple nullSubst $ TAtom (TypCon "Bool"))
   (Atom (Char _)) -> return (Tuple nullSubst $ TAtom (TypCon "Char"))
   (Atom (AInt _)) -> return (Tuple nullSubst $ TAtom (TypCon "Int"))
@@ -383,8 +386,6 @@ inferOp env op = do
       f ((b `TypArr` c) `TypArr` ((a `TypArr` b) `TypArr` (a `TypArr` c)))
     Power -> int3
     Mul ->  int3
-    Div -> int3
-    Mod -> int3
     Add -> int3
     Sub -> int3
     Colon -> f (a `TypArr` ((AD $ TList a) `TypArr` (AD $ TList a)))

--- a/test/TestParser.purs
+++ b/test/TestParser.purs
@@ -51,8 +51,8 @@ runTests = do
   test "composition" expression "f . g" (Binary Composition (aname "f") (aname "g"))
   test "power" expression "2 ^ 10" (Binary Power (aint 2) (aint 10))
   test "mul" expression "2 * 2" (Binary Mul (aint 2) (aint 2))
-  test "div" expression "13 `div` 3" (Binary Div (aint 13) (aint 3))
-  test "mod" expression "13 `mod` 3" (Binary Mod (aint 13) (aint 3))
+  test "div" expression "13 `div` 3" (Binary (InfixFunc "div") (aint 13) (aint 3))
+  test "mod" expression "13 `mod` 3" (Binary (InfixFunc "mod") (aint 13) (aint 3))
   test "add1" expression "1 + 1"  (Binary Add (aint 1) (aint 1))
   test "add2" expression "2+2" (Binary Add (aint 2) (aint 2))
   test "sub" expression "5 - 3" (Binary Sub (aint 5) (aint 3))
@@ -87,7 +87,7 @@ runTests = do
                                     (Binary Mul (aint 3) (aint 4)))
   test "whitespaces" expression 
     "1   \t   -    \t   ( f   )    \t\t\t\t                                                                \t\t\t\t             `div`     _ignore"
-    (Binary Sub (aint 1) (Binary Div (aname "f") (aname "_ignore")))
+    (Binary Sub (aint 1) (Binary (InfixFunc "div") (aname "f") (aname "_ignore")))
   test "brackets" expression "(  1  +  2  )  *  3" (Binary Mul (Binary Add (aint 1) (aint 2)) (aint 3))
   test "brackets2" expression "( (  1  +  2  - 3  )  *  4 * 5 * 6)"
     (Binary Mul 
@@ -237,7 +237,7 @@ runTests = do
   test "prefixOp3" expression "((^) 2 10)" (App (PrefixOp Power) (toList [aint 2, aint 10]))
 
   test "sectL1" expression "(1+)" (SectL (aint 1) Add)
-  test "sectL2" expression "( n `mod` )" (SectL (aname "n") Mod)
+  test "sectL2" expression "( n `mod` )" (SectL (aname "n") (InfixFunc "mod"))
   test "sectL3" expression "([1] ++)" (SectL (List $ toList [aint 1]) Append)
   test "sectL4" expression "(   ( 2 +  2 )  <= )" (SectL (Binary Add (aint 2) (aint 2)) Leq)
 
@@ -474,7 +474,7 @@ parsedPrelude = toList [
   (Def "id" (Cons (Lit (Name "x")) (Nil)) (Atom (Name "x"))),
   (Def "const" (Cons (Lit (Name "x")) (Cons (Lit (Name "_")) (Nil))) (Atom (Name "x"))),
   (Def "flip" (Cons (Lit (Name "f")) (Cons (Lit (Name "x")) (Cons (Lit (Name "y")) (Nil)))) (App (Atom (Name "f")) (Cons (Atom (Name "y")) (Cons (Atom (Name "x")) (Nil))))),
-  (Def "even" (Cons (Lit (Name "n")) (Nil)) (Binary Equ (Binary Mod (Atom (Name "n")) (Atom (AInt 2))) (Atom (AInt 0)))),
-  (Def "odd" (Cons (Lit (Name "n")) (Nil)) (Binary Equ (Binary Mod (Atom (Name "n")) (Atom (AInt 2))) (Atom (AInt 1)))),
+  (Def "even" (Cons (Lit (Name "n")) (Nil)) (Binary Equ (Binary (InfixFunc "mod") (Atom (Name "n")) (Atom (AInt 2))) (Atom (AInt 0)))),
+  (Def "odd" (Cons (Lit (Name "n")) (Nil)) (Binary Equ (Binary (InfixFunc "mod") (Atom (Name "n")) (Atom (AInt 2))) (Atom (AInt 1)))),
   (Def "fix" (Cons (Lit (Name "f")) (Nil)) (App (Atom (Name "f")) (Cons (App (Atom (Name "fix")) (Cons (Atom (Name "f")) (Nil))) (Nil))))
   ]


### PR DESCRIPTION
"div" and "mod" are hardcoded, can be used like ordinary function but are evaluated with the div- and mod- function of purescript in one step, if both arguments are atoms

div and mod are no longer Operators of the Op-Type and are parsed as follows (example for div): 
Binary (InfixOp "div") expr1 expr2
App (Atom (Name "div")) args
