### PR TITLE
Updates for PureScript 0.9.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
     "purescript-jquery": "0.6.x",
     "purescript-globals": "0.2.x",
     "purescript-ace": "0.11.x",
-    "purescript-node-process": "0.4.x",
     "purescript-words-lines": "~0.0.2",
     "purescript-sets": "0.5.x"
   },

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,8 @@
     "purescript-lists": "^1.0.0",
     "purescript-maps": "^1.0.0",
     "purescript-parsing": "^1.0.0",
-    "purescript-partial": "^1.0.0",
     "purescript-sets": "^1.0.0",
-    "purescript-transformers": "^1.0.0"
+    "purescript-transformers": "^1.0.0",
+    "purescript-node-process": "^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,19 +15,16 @@
     "html/dist/*"
   ],
   "dependencies": {
-    "purescript-arrays": "0.4.x",
-    "purescript-lists": "~0.7.x",
-    "purescript-transformers": "~0.8.x",
-    "purescript-parsing": "~0.8.x",
-    "purescript-dom": "~0.2.x",
-    "purescript-maps": "~0.5.x",
-    "purescript-jquery": "0.6.x",
-    "purescript-globals": "0.2.x",
-    "purescript-ace": "0.11.x",
-    "purescript-words-lines": "~0.0.2",
-    "purescript-sets": "0.5.x"
-  },
-  "resolutions": {
-    "purescript-prelude": "^0.1.0"
+    "purescript-ace": "^1.0.0",
+    "purescript-arrays": "^1.0.0",
+    "purescript-dom": "^1.0.0",
+    "purescript-globals": "^1.0.0",
+    "purescript-jquery": "^1.0.0",
+    "purescript-lists": "^1.0.0",
+    "purescript-maps": "^1.0.0",
+    "purescript-parsing": "^1.0.0",
+    "purescript-partial": "^1.0.0",
+    "purescript-sets": "^1.0.0",
+    "purescript-transformers": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "npm": "*"
   },
   "dependencies": {
-    "purescript": "0.10.1",
+    "purescript": "0.9.3",
     "pulp": "9.0.1",
     "bower": "*"
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "npm": "*"
   },
   "dependencies": {
-    "purescript": "0.8.5",
-    "pulp": "8.2.1",
+    "purescript": "0.10.1",
+    "pulp": "9.0.1",
     "bower": "*"
   },
   "scripts": {

--- a/src/AST.purs
+++ b/src/AST.purs
@@ -1,6 +1,6 @@
 module AST where
 
-import Prelude (class Show, class Eq, class Ord, show, (++))
+import Prelude (class Show, class Eq, class Ord, show, (<>))
 import Data.List (List)
 import Data.Maybe (Maybe)
 import Data.Tuple (Tuple)
@@ -166,10 +166,10 @@ data Path = Nth Int Path
 
 instance showPath :: Show Path where
   show p = case p of
-    Nth i p -> "(Nth " ++ show i ++ " " ++ show p ++")"
-    Fst   p -> "(Fst " ++ show p ++")"
-    Snd   p -> "(Snd " ++ show p ++")"
-    Thrd   p -> "(Thrd " ++ show p ++")"
+    Nth i p -> "(Nth " <> show i <> " " <> show p <>")"
+    Fst   p -> "(Fst " <> show p <>")"
+    Snd   p -> "(Snd " <> show p <>")"
+    Thrd   p -> "(Thrd " <> show p <>")"
     End     -> "End"
 
 derive instance eqDefinition :: Eq Definition
@@ -192,7 +192,7 @@ instance showOp :: Show Op where
     And    -> "And"
     Or     -> "Or"
     Dollar -> "Dollar"
-    InfixFunc name -> "(InfixFunc " ++ name ++ ")"
+    InfixFunc name -> "(InfixFunc " <> name <> ")"
 
 pPrintOp :: Op -> String
 pPrintOp op = case op of
@@ -202,7 +202,7 @@ pPrintOp op = case op of
   Add    -> "+"
   Sub    -> "-"
   Colon  -> ":"
-  Append -> "++"
+  Append -> "<>"
   Equ    -> "=="
   Neq    -> "/="
   Lt     -> "<"
@@ -212,59 +212,59 @@ pPrintOp op = case op of
   And    -> "&&"
   Or     -> "||"
   Dollar -> "$"
-  InfixFunc n -> "`" ++ n ++ "`"
+  InfixFunc n -> "`" <> n <> "`"
 
 instance showAtom :: Show Atom where
   show atom = case atom of
-    AInt number -> "AInt " ++ show number
-    Bool bool   -> "Bool " ++ show bool
-    Char string -> "Char " ++ show string
-    Name string -> "Name " ++ show string
+    AInt number -> "AInt " <> show number
+    Bool bool   -> "Bool " <> show bool
+    Char string -> "Char " <> show string
+    Name string -> "Name " <> show string
 
 instance showQual :: (Show b, Show e) => Show (Qual b e) where
   show q = case q of
-    Gen b e -> "Gen (" ++ show b ++ " " ++ show e ++ ")"
-    Let b e -> "Let (" ++ show b ++ " " ++ show e ++ ")"
-    Guard e -> "Guard (" ++ show e ++ ")" 
+    Gen b e -> "Gen (" <> show b <> " " <> show e <> ")"
+    Let b e -> "Let (" <> show b <> " " <> show e <> ")"
+    Guard e -> "Guard (" <> show e <> ")"
 
 instance showQualTree :: (Show a, Show b, Show c) => Show (QualTree a b c) where
-  show (TGen a b c) = "TGen (" ++ show a ++ " " ++ show b ++ " " ++ show c ++ ")"
-  show (TLet a b c) = "TLet (" ++ show a ++ " " ++ show b ++ " " ++ show c ++ ")"
-  show (TGuard a c)  = "TGuard (" ++ show a ++ " " ++ show c ++ ")"
+  show (TGen a b c) = "TGen (" <> show a <> " " <> show b <> " " <> show c <> ")"
+  show (TLet a b c) = "TLet (" <> show a <> " " <> show b <> " " <> show c <> ")"
+  show (TGuard a c)  = "TGuard (" <> show a <> " " <> show c <> ")"
 
 instance showExpr :: Show Expr where
   show expr = case expr of
-    Atom atom       -> "Atom (" ++ show atom ++ ")"
-    List ls         -> "List (" ++ show ls ++ ")"
-    NTuple ls       -> "NTuple (" ++ show ls ++ ")"
-    Binary op e1 e2 -> "Binary " ++ show op ++ " (" ++ show e1 ++ ") (" ++ show e2 ++ ")"
-    Unary op e      -> "Unary " ++ show op ++ " (" ++ show e ++ ")"
-    SectL expr op   -> "SectL (" ++ show expr ++ ") " ++ show op
-    SectR op expr   -> "SectR " ++ show op ++ " (" ++ show expr ++ ")"
-    PrefixOp op     -> "PrefixOp " ++ show op
-    IfExpr ce te ee  -> "IfExpr (" ++ show ce ++ ") (" ++ show te ++ ") (" ++ show ee ++ ")"
-    ArithmSeq s by e -> "ArithmSeq (" ++ show s ++ ")" ++ show by ++ ".." ++ show e ++ ")"
-    LetExpr b e   -> "LetExpr (" ++ show b ++ ") (" ++ show e ++ ")"
-    Lambda binds body -> "Lambda (" ++ show binds ++ ") (" ++ show body ++ ")"
-    App func args   -> "App (" ++ show func ++ ") (" ++ show args ++ ")"
-    ListComp expr quals -> "ListComp (" ++ show expr ++ ")" ++ "(" ++ show quals ++ "))"
+    Atom atom       -> "Atom (" <> show atom <> ")"
+    List ls         -> "List (" <> show ls <> ")"
+    NTuple ls       -> "NTuple (" <> show ls <> ")"
+    Binary op e1 e2 -> "Binary " <> show op <> " (" <> show e1 <> ") (" <> show e2 <> ")"
+    Unary op e      -> "Unary " <> show op <> " (" <> show e <> ")"
+    SectL expr op   -> "SectL (" <> show expr <> ") " <> show op
+    SectR op expr   -> "SectR " <> show op <> " (" <> show expr <> ")"
+    PrefixOp op     -> "PrefixOp " <> show op
+    IfExpr ce te ee  -> "IfExpr (" <> show ce <> ") (" <> show te <> ") (" <> show ee <> ")"
+    ArithmSeq s by e -> "ArithmSeq (" <> show s <> ")" <> show by <> ".." <> show e <> ")"
+    LetExpr b e   -> "LetExpr (" <> show b <> ") (" <> show e <> ")"
+    Lambda binds body -> "Lambda (" <> show binds <> ") (" <> show body <> ")"
+    App func args   -> "App (" <> show func <> ") (" <> show args <> ")"
+    ListComp expr quals -> "ListComp (" <> show expr <> ")" <> "(" <> show quals <> "))"
 
 instance showBinding :: Show Binding where
   show binding = case binding of
-    Lit atom     -> "Lit (" ++ show atom ++ ")"
-    ConsLit b bs -> "ConsLit (" ++ show b ++ ") (" ++ show bs ++ ")"
-    ListLit bs   -> "ListLit (" ++ show bs ++ ")"
-    NTupleLit ls -> "NTupleLit (" ++ show ls ++ ")"
+    Lit atom     -> "Lit (" <> show atom <> ")"
+    ConsLit b bs -> "ConsLit (" <> show b <> ") (" <> show bs <> ")"
+    ListLit bs   -> "ListLit (" <> show bs <> ")"
+    NTupleLit ls -> "NTupleLit (" <> show ls <> ")"
 
 instance showDefinition :: Show Definition where
-  show (Def name bindings body) = "Def " ++ show name ++ " (" ++ show bindings ++ ") (" ++ show body ++ ")"
+  show (Def name bindings body) = "Def " <> show name <> " (" <> show bindings <> ") (" <> show body <> ")"
 
 instance showType :: Show Type where
-  show (TypVar var) = "(TypVar  " ++ show var ++ ")"
-  show (TypCon con) = "(TypCon " ++ show con ++ ")"
-  show (TypArr t1 t2) = "(TypArr "++ show t1 ++" " ++ show t2 ++ ")"
-  show (AD ad) = "(AD "++ show ad ++ ")"
-  show (TypeError err) ="(TypeError "++ show err ++")"
+  show (TypVar var) = "(TypVar  " <> show var <> ")"
+  show (TypCon con) = "(TypCon " <> show con <> ")"
+  show (TypArr t1 t2) = "(TypArr "<> show t1 <>" " <> show t2 <> ")"
+  show (AD ad) = "(AD "<> show ad <> ")"
+  show (TypeError err) ="(TypeError "<> show err <>")"
 
 derive instance eqType :: Eq Type
 
@@ -273,45 +273,45 @@ derive instance ordTVar :: Ord TVar
 derive instance eqTVar :: Eq TVar
 
 instance showTVar :: Show TVar where
-  show (TVar a) = "(TVar " ++ show a ++ ")"
+  show (TVar a) = "(TVar " <> show a <> ")"
 
 instance showAD :: Show AD where
-  show (TList t) = "(TList "++ show t ++")"
-  show (TTuple tl) = "(TTuple ("++ show tl ++ "))"
+  show (TList t) = "(TList "<> show t <>")"
+  show (TTuple tl) = "(TTuple ("<> show tl <> "))"
 
 derive instance eqAD :: Eq AD
 
 instance showTypeError :: Show TypeError where
-  show (UnificationFail a b) = "(UnificationFail "++ show a ++ " " ++ show b ++")"
-  show (InfiniteType a b ) = "(InfiniteType " ++ show a ++ " " ++ show b ++ ")"
-  show (UnboundVariable a) = "(UnboundVariable " ++ show a ++ ")"
-  show (UnificationMismatch a b) = "(UnificationMismatch " ++ show a ++ " " ++ show b ++ ")"
-  show (UnknownError s) = "(UnknownError " ++ s ++ ")"
-  show (NoInstanceOfEnum t) = "(" ++ show t ++ "is no instance of Enum)"
+  show (UnificationFail a b) = "(UnificationFail "<> show a <> " " <> show b <>")"
+  show (InfiniteType a b ) = "(InfiniteType " <> show a <> " " <> show b <> ")"
+  show (UnboundVariable a) = "(UnboundVariable " <> show a <> ")"
+  show (UnificationMismatch a b) = "(UnificationMismatch " <> show a <> " " <> show b <> ")"
+  show (UnknownError s) = "(UnknownError " <> s <> ")"
+  show (NoInstanceOfEnum t) = "(" <> show t <> "is no instance of Enum)"
 
 derive instance eqTypeError :: Eq TypeError
 
 instance showTypeTree :: Show TypeTree where
-  show (TAtom t) = "(TAtom " ++ show t ++ ")"
-  show (TListTree lt t) = "(TListTree (" ++ show lt ++ ") " ++ show t ++ ")"
-  show (TNTuple lt t) = "(TNTuple ("++ show lt ++ ") " ++ show t ++ ")"
-  show (TBinary t1 tt1 tt2 t) = "(TBinary " ++ show t1 ++ " " ++ show tt1 ++  " " ++ show tt2 ++ " " ++ show t ++ ")"
-  show (TUnary t1 tt t) = "(TUnary "++ show t1 ++ " " ++ show tt ++ " " ++ show t ++ ")"
-  show (TSectL tt t1 t) = "(TSectL "++ show tt ++ " "++ show t1 ++ " " ++ show t ++ ")"
-  show (TSectR t1 tt t) = "(TSectR " ++ show t1 ++ " " ++ show tt ++ " " ++ show t ++ ")"
-  show (TPrefixOp t) = "(TPrefixOp " ++ show t ++ ")"
-  show (TIfExpr tt1 tt2 tt3 t) = "(TIfExpr " ++ show tt1 ++ " " ++ show tt2 ++ " " ++ show tt3 ++ " " ++ show t ++ ")"
-  show (TArithmSeq s b e t) = "(TArithmSeq " ++ show s ++ " " ++ show b ++ " " ++ show e ++ ".." ++ show t ++ ")"
-  show (TLetExpr bin tt t) = "(TLetExpr " ++ show bin ++ " " ++ show tt ++ " " ++ show t ++ ")"
-  show (TLambda lb tt t ) = "(TLambda " ++ show lb ++ " " ++ show tt ++ " " ++ show t ++ ")"
-  show (TApp tt1 tl t) = "(TApp " ++ show tt1 ++ " (" ++ show tl ++ ") " ++ show t ++ ")"
-  show (TListComp e qs t) = "(TListComp " ++ show e ++ " (" ++ show qs ++ ") " ++ show t ++ ")"
+  show (TAtom t) = "(TAtom " <> show t <> ")"
+  show (TListTree lt t) = "(TListTree (" <> show lt <> ") " <> show t <> ")"
+  show (TNTuple lt t) = "(TNTuple ("<> show lt <> ") " <> show t <> ")"
+  show (TBinary t1 tt1 tt2 t) = "(TBinary " <> show t1 <> " " <> show tt1 <>  " " <> show tt2 <> " " <> show t <> ")"
+  show (TUnary t1 tt t) = "(TUnary "<> show t1 <> " " <> show tt <> " " <> show t <> ")"
+  show (TSectL tt t1 t) = "(TSectL "<> show tt <> " "<> show t1 <> " " <> show t <> ")"
+  show (TSectR t1 tt t) = "(TSectR " <> show t1 <> " " <> show tt <> " " <> show t <> ")"
+  show (TPrefixOp t) = "(TPrefixOp " <> show t <> ")"
+  show (TIfExpr tt1 tt2 tt3 t) = "(TIfExpr " <> show tt1 <> " " <> show tt2 <> " " <> show tt3 <> " " <> show t <> ")"
+  show (TArithmSeq s b e t) = "(TArithmSeq " <> show s <> " " <> show b <> " " <> show e <> ".." <> show t <> ")"
+  show (TLetExpr bin tt t) = "(TLetExpr " <> show bin <> " " <> show tt <> " " <> show t <> ")"
+  show (TLambda lb tt t ) = "(TLambda " <> show lb <> " " <> show tt <> " " <> show t <> ")"
+  show (TApp tt1 tl t) = "(TApp " <> show tt1 <> " (" <> show tl <> ") " <> show t <> ")"
+  show (TListComp e qs t) = "(TListComp " <> show e <> " (" <> show qs <> ") " <> show t <> ")"
 
 instance showTypeBinding:: Show TypeBinding where
-  show (TLit t) = "(TLit "++ show t ++")"
-  show (TConsLit b1 b2 t) = "(TConsLit "++ show b1 ++ " " ++ show b2 ++ " " ++ show t ++")"
-  show (TListLit lb t) = "(TListLit " ++ show lb ++ " "++ show t ++")"
-  show (TNTupleLit lb t) = "(TNTupleLit " ++ show lb ++ " "++ show t ++")"
+  show (TLit t) = "(TLit "<> show t <>")"
+  show (TConsLit b1 b2 t) = "(TConsLit "<> show b1 <> " " <> show b2 <> " " <> show t <>")"
+  show (TListLit lb t) = "(TListLit " <> show lb <> " "<> show t <>")"
+  show (TNTupleLit lb t) = "(TNTupleLit " <> show lb <> " "<> show t <>")"
 
 extractType:: TypeTree -> Type
 extractType (TAtom t)            = t

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1,6 +1,6 @@
 module Main where
 
-import Prelude (class Applicative, Unit, (<$>), bind, show, ($), (>>=), void, unit, return, (++), id, (+), flip, (<<<), (-))
+import Prelude (class Applicative, Unit, (<$>), bind, show, ($), (>>=), (*>), void, unit, pure, id, (<>), (+), flip, (<<<), (-))
 import Data.Foreign (unsafeFromForeign)
 import Data.Foldable (any)
 import Data.Either (Either(Right, Left), either)
@@ -9,13 +9,14 @@ import Data.List (List(Nil), (:), singleton, (!!), drop, deleteAt, length, (..),
 
 import Control.Monad.Eff.JQuery as J
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, print)
+import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.State.Trans (StateT, modify, get, runStateT)
 import Control.Monad.Eff.Class (liftEff)
 
 import Text.Parsing.Parser (ParseError(ParseError))
 import Text.Parsing.Parser.Pos (Position(Position))
 import DOM (DOM)
+import Ace as Ace
 import Ace.Types (ACE())
 import Ace.Editor as Editor
 import Ace.EditSession as Session
@@ -32,7 +33,7 @@ main :: DOMEff J.JQuery
 main = J.ready $ do
   J.select "#input"
     >>= J.on "change" (\_ _ -> startEvaluation)
-    >>= J.on "keyup"  (\e _ -> if isEnterKey e then startEvaluation else return unit)
+    >>= J.on "keyup"  (\e _ -> if isEnterKey e then startEvaluation else pure unit)
   startEvaluation
 
 type DOMEff = Eff (dom :: DOM, console :: CONSOLE, ace :: ACE)
@@ -71,7 +72,7 @@ startEvaluation = do
 outIfErr::forall b. String -> Either TypeError b -> DOMEff Unit
 outIfErr origin either = case either of
   Left err -> showInfo origin (prettyPrintTypeError err)
-  Right _ -> return unit
+  Right _ -> pure unit
 
 markText :: Int -> Int -> DOMEff Unit
 markText line column = do
@@ -98,8 +99,15 @@ showEvaluationState = do
   showHistory <- liftEff $ isChecked historyCheckbox
 
   if showHistory
-    then showHistoryList histExprs >>= liftEff <<< flip J.append history
-    else liftEff $ J.create "<p></p>" >>= J.setText "hidden" >>=  flip J.append history
+    then do
+      jq <- showHistoryList histExprs
+      liftEff $ J.append jq history
+      pure jq
+    else liftEff $ do
+      paragraph <- J.create "<p></p>"
+      J.setText "hidden" paragraph
+      J.append paragraph history
+      pure paragraph
 
   liftEff (J.find ".binary, .app, .func, .list, .if, .name" output)
      >>= makeClickable
@@ -108,27 +116,35 @@ showEvaluationState = do
     >>= addClickListener (out.typ)
   liftEff (J.body >>= J.on "mouseover" (\_ _ -> removeMouseOver))
 
-  liftEff $ return unit :: DOMEff Unit
+  liftEff $ pure unit :: DOMEff Unit
 
 forIndex :: forall m a b. (Applicative m) => (List a) -> (a -> Int -> m b) -> m (List b)
 forIndex as f = zipWithA f as (0 .. (length as - 1))
 
 showHistoryList :: (List Output) -> EvalM J.JQuery
 showHistoryList exprs = do
-  box <- liftEff $ J.create "<table></table>" >>= J.addClass "historyBox" >>= J.addClass "vertical" >>= J.addClass "frame"
+  box <- liftEff $ do
+    table <- J.create "<table></table>"
+    J.addClass "historyBox" table
+    J.addClass "vertical" table
+    J.addClass "frame" table
+    pure table
   forIndex exprs $ \expr i -> do
     showHistoryRow expr i >>= liftEff <<< flip J.append box
-  scroll <- liftEff $ J.create "<div></div>" >>= J.addClass "scroll"
+  scroll <- liftEff $ J.create "<div></div>" >>= \div -> J.addClass "scroll" div *> pure div
   liftEff $ J.append box scroll
-  return scroll
+  pure scroll
 
 
 showHistoryRow :: Output -> Int -> EvalM J.JQuery
 showHistoryRow out i = do
-  row <- liftEff $ J.create "<tr></tr>" >>= J.addClass "history"
+  row <- liftEff $ do
+    hist <- J.create "<tr></tr>"
+    J.addClass "history" hist
+    pure hist
   tdExpr <- liftEff $ J.create "<td></td>"
   liftEff $ exprToJQuery out >>= flip J.append tdExpr
-  liftEff $ J.append tdExpr row
+  liftEff $ (J.append tdExpr row *> pure row)
   es <- get :: EvalM EvalState
   -- let deleteHandler = \_ _ -> do
   --                       let es' = es { history = maybe es.history id (deleteAt i es.history) }
@@ -143,39 +159,48 @@ showHistoryRow out i = do
   let restoreHandler = \_ _ -> do
                          let es' = es { history = drop (i + 1) es.history, out = maybe es.out id (es.history !! i) }
                          void $ runStateT showEvaluationState es'
-  restore <- liftEff $ J.create "<button></button>"
-    >>= J.setText "Restore"
-    >>= J.addClass "restore"
-    >>= J.on "click" restoreHandler
+  restore <- liftEff $ do
+    button <- J.create "<button></button>"
+    J.setText "Restore" button
+    J.addClass "restore" button
+    J.on "click" restoreHandler button
+    pure button
   tdRestore <- liftEff $ J.create "<td></td>"
   liftEff $ J.append restore tdRestore
   liftEff $ J.append tdRestore row
-  return row
+  pure row
 
 showInfo :: String -> String -> DOMEff Unit
 showInfo origin msg = do
-  info <- J.create "<p></p>"
-    >>= J.addClass "info"
-    >>= J.setText ("Error in " ++ origin ++ " => " ++ msg)
+  info <- do
+    paragraph <- J.create "<p></p>"
+    J.addClass "info" paragraph
+    J.setText ("Error in " <> origin <> " => " <> msg) paragraph
+    pure paragraph
   clearInfo
   J.select "#info"
     >>= J.append info
-  return unit
+  pure unit
 
 clearInfo :: DOMEff Unit
 clearInfo = void $ J.select "#info" >>= J.clear
 
 prepareContainer :: String -> DOMEff J.JQuery
 prepareContainer name = do
-  J.select ("#" ++ name ++ "-container") >>= J.clear
+  selection <- J.select ("#" <> name <> "-container")
+  J.clear selection
+  pure selection
 
 wrapInDiv :: String -> J.JQuery -> DOMEff J.JQuery
 wrapInDiv name jq = do
-  J.create "<div></div>" >>= J.addClass name >>= J.append jq
+  div <- J.create "<div></div>"
+  J.addClass name div
+  J.append jq div
+  pure div
 
 makeClickable :: J.JQuery -> EvalM Unit
 makeClickable jq = do
-  { env: env, out: out } <- get
+  { env: env, out: out } :: EvalState <- get
   let expr = out.expr
   let typeTree = out.typ
   liftEff $ jqMap (testEval env expr typeTree) jq
@@ -184,51 +209,54 @@ makeClickable jq = do
   testEval env expr typeTree jq = do
     mpath <- getPath jq
     case mpath of
-      Nothing   -> return unit
+      Nothing   -> pure unit
       Just path ->
         case evalPath1 env path expr of
           Left err -> displayEvalError err jq
           Right _  -> if checkForError path typeTree
-            then return unit
+            then pure unit
             else void $ J.addClass "clickable" jq
 
 displayEvalError :: EvalError -> J.JQuery -> DOMEff Unit
 displayEvalError err jq = case err of
   DivByZero -> void $ makeDiv "Division by zero!" (singleton "evalError") >>= flip prepend jq
   NoMatchingFunction _ errs -> if (any missesArguments errs)
-    then return unit
+    then pure unit
     else void $ makeDiv "No matching function!" (singleton "evalError") >>= flip prepend jq
-  _         -> return unit
+  _         -> pure unit
   where
     missesArguments (TooFewArguments _ _) = true
     missesArguments (StrictnessError _ _) = true
     missesArguments _                     = false
 
 addMouseOverListener :: J.JQuery -> EvalM J.JQuery
-addMouseOverListener jq = liftEff $ J.on "mouseover" handler jq
+addMouseOverListener jq = liftEff $ do
+    J.on "mouseover" handler jq
+    pure jq
   where
   handler :: J.JQueryEvent -> J.JQuery -> DOMEff Unit
   handler jEvent jq = do
     J.stopPropagation jEvent
     removeMouseOver
     J.addClass "mouseOver" jq
-    return unit
+    pure unit
 
 addClickListener :: TypeTree ->  J.JQuery -> EvalM J.JQuery
 addClickListener typeTree jq = do
   evaluationState <- get
   liftEff $ J.on "click" (handler evaluationState) jq
+  pure jq
   where
   handler :: EvalState -> J.JQueryEvent -> J.JQuery -> DOMEff Unit
   handler evaluationState jEvent jq = do
     J.stopImmediatePropagation jEvent
     mpath <- getPath jq
     case mpath of
-      Nothing   -> return unit
+      Nothing   -> pure unit
       Just path -> do
-        return unit
+        pure unit
         if checkForError path typeTree
-          then return unit
+          then pure unit
           else case ctrlKeyPressed jEvent of
                 false -> void $ runStateT (evalExpr evalPath1 path) evaluationState
                 true  -> void $ runStateT (evalExpr evalPathAll path) evaluationState
@@ -242,7 +270,7 @@ evalExpr eval path = do
   let expr = out.expr
   -- liftEff $ print path
   case eval env path expr of
-    Left msg    -> return unit
+    Left msg    -> pure unit
     Right expr' -> do
         let eitherTyp = typeTreeProgramnEnv typEnv expr'
         let typ'' = either (\_ -> buildPartiallyTypedTree typEnv expr') id eitherTyp

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -88,7 +88,7 @@ showEvaluationState = do
   typContainer <- liftEff $ prepareContainer "typ"
   svgContainer <- liftEff $ prepareContainer "svg"
 
-  { env = env, out = out, history = histExprs } <- get :: EvalM EvalState
+  { env: env, out: out, history: histExprs } <- get :: EvalM EvalState
   -- liftEff $ print out.expr
   -- liftEff $ print out.typ
 
@@ -175,7 +175,7 @@ wrapInDiv name jq = do
 
 makeClickable :: J.JQuery -> EvalM Unit
 makeClickable jq = do
-  { env = env, out = out } <- get
+  { env: env, out: out } <- get
   let expr = out.expr
   let typeTree = out.typ
   liftEff $ jqMap (testEval env expr typeTree) jq
@@ -238,7 +238,7 @@ removeMouseOver = void $ J.select ".mouseOver" >>= J.removeClass "mouseOver"
 
 evalExpr :: (Env -> Path -> Expr -> Either EvalError Expr) -> Path -> EvalM Unit
 evalExpr eval path = do
-  { env = env, out = out, typEnv = typEnv} <- get
+  { env: env, out: out, typEnv: typEnv} <- get
   let expr = out.expr
   -- liftEff $ print path
   case eval env path expr of

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -5,7 +5,7 @@ import Data.Foreign (unsafeFromForeign)
 import Data.Foldable (any)
 import Data.Either (Either(Right, Left), either)
 import Data.Maybe (Maybe(Just, Nothing), maybe)
-import Data.List (List(Nil), (:), singleton, (!!), drop, deleteAt, length, (..), zipWithA)
+import Data.List (List(Nil), (:), singleton, (!!), drop, length, (..), zipWithA)
 
 import Control.Monad.Eff.JQuery as J
 import Control.Monad.Eff (Eff)
@@ -29,11 +29,11 @@ import TypeChecker (TypeEnv, txToABC, buildPartiallyTypedTree, typeTreeProgramnE
 import Parser (parseDefs, parseExpr)
 import JSHelpers (ctrlKeyPressed, prepend, jqMap, warnOnRefresh, isEnterKey, showTypes, isChecked)
 
-main :: DOMEff J.JQuery
+main :: DOMEff Unit
 main = J.ready $ do
-  J.select "#input"
-    >>= J.on "change" (\_ _ -> startEvaluation)
-    >>= J.on "keyup"  (\e _ -> if isEnterKey e then startEvaluation else pure unit)
+  selection <- J.select "#input"
+  J.on "change" (\_ _ -> startEvaluation) selection
+  J.on "keyup"  (\e _ -> if isEnterKey e then startEvaluation else pure unit) selection
   startEvaluation
 
 type DOMEff = Eff (dom :: DOM, console :: CONSOLE, ace :: ACE)

--- a/src/TypeChecker.purs
+++ b/src/TypeChecker.purs
@@ -1,6 +1,6 @@
 module TypeChecker where
 
-import Prelude (class Monad, class Show, class Eq, (&&), (==), (/=), (>>=), map, (++), ($), pure, (<*>), (<$>), (||), return, bind, const, otherwise, show, (+), div, mod, flip)
+import Prelude (class Monad, class Show, class Eq, (&&), (==), (/=), (>>=), map, (<>), ($), pure, (<*>), (<$>), (||), bind, const, otherwise, show, (+), div, mod, flip)
 
 import Control.Monad.Except.Trans (ExceptT, runExceptT, throwError)
 import Control.Monad.State (State, evalState, runState, put, get)
@@ -8,22 +8,25 @@ import Control.Apply (lift2)
 import Control.Bind (ifM)
 
 import Data.Either (Either(Left, Right))
-import Data.List (List(..), filter, delete, concatMap, unzip, foldM, (:), zip, singleton, toList, length, concat, (!!))
-import Data.List.WordsLines (fromCharList)
+import Data.List (List(..), filter, delete, concatMap, unzip, foldM, (:), zip, singleton, length, concat, (!!))
+import Data.List as List
+import Data.Array (toUnfoldable)
+import Data.Array as Array
 import Data.Map as Map
 import Data.Map (Map, insert, lookup, empty)
 import Data.Tuple (Tuple(Tuple), snd, fst)
 import Data.Set as Set
 import Data.Foldable (foldl, foldr, foldMap)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
-import Data.String (toCharArray)
+import Data.String (toCharArray, fromCharArray)
+-- import Partial.Unsafe (unsafePartial)
 
 import AST (AD(..), Atom(..), Binding(..), Definition(..), Expr(..), Qual(..), ExprQual, QualTree(..), TypeQual, Op(..), TVar(..), Type(..), TypeBinding(..), TypeTree(..),TypeError(..),Path(..), extractType, extractBindingType)
 
 data Scheme = Forall (List TVar) Type
 
 instance showScheme :: Show Scheme where
-  show (Forall a b) = "Forall (" ++ show a ++ ") " ++ show b
+  show (Forall a b) = "Forall (" <> show a <> ") " <> show b
 
 data TypeEnv = TypeEnv (Map.Map Atom Scheme)
 
@@ -50,7 +53,7 @@ class Substitutable a where
 instance subScheme :: Substitutable Scheme where
     apply s (Forall as t)   = Forall as $ apply s' t
                               where s' = foldr Map.delete s as
-    ftv (Forall as t) = (ftv t) `Set.difference` Set.fromList as
+    ftv (Forall as t) = (ftv t) `Set.difference` Set.fromFoldable as
 
 instance subType :: Substitutable Type where
    apply _ (TypCon a) = TypCon a
@@ -162,19 +165,19 @@ fresh :: Infer Type
 fresh = do
   (Unique s) <- get
   put (Unique {count:(s.count+1)})
-  return $ TypVar $ TVar $ "t_" ++ show s.count
+  pure $ TypVar $ TVar $ "t_" <> show s.count
 
 
 unify ::  Type -> Type -> Infer Subst
 unify (TypArr l r) (TypArr l' r')  = do
     s1 <- unify l l'
     s2 <- unify (apply s1 r) (apply s1 r')
-    return (s2 `compose` s1)
+    pure (s2 `compose` s1)
 
 unify (TypVar a) t = bindVar a t
 unify t (TypVar a) = bindVar a t
-unify (TypCon a) (TypCon b) | a == b = return nullSubst
-unify (AD a) (AD b) | a == b = return nullSubst
+unify (TypCon a) (TypCon b) | a == b = pure nullSubst
+unify (AD a) (AD b) | a == b = pure nullSubst
 unify (AD a) (AD b) = unifyAD a b
 unify t1 t2 = throwError $ UnificationFail t1 t2
 
@@ -183,16 +186,16 @@ unifyAD (TList a) (TList b) = unify a b
 unifyAD (TTuple (Cons a as)) (TTuple (Cons b bs)) = do
   s1 <- unifyAD (TTuple as) (TTuple bs)
   s2 <- unify a b
-  return (s1 `compose` s2)
-unifyAD (TTuple Nil) (TTuple Nil) = return nullSubst
+  pure (s1 `compose` s2)
+unifyAD (TTuple Nil) (TTuple Nil) = pure nullSubst
 
 unifyAD a b = throwError $ UnificationFail (AD a) (AD b)
 
 
 bindVar ::  TVar -> Type -> Infer Subst
-bindVar a t | t == (TypVar a)     = return nullSubst
+bindVar a t | t == (TypVar a)     = pure nullSubst
          | occursCheck a t = throwError $ InfiniteType a t
-         | otherwise       = return $ Map.singleton a t
+         | otherwise       = pure $ Map.singleton a t
 
 occursCheck :: forall a.  (Substitutable a) => TVar -> a -> Boolean
 occursCheck a t = a `Set.member` ftv t
@@ -207,11 +210,11 @@ instantiate ::  Scheme -> Infer Type
 instantiate (Forall as t) = do
   as' <- mapM (const fresh) as
   let s = Map.fromList $ zip as as'
-  return $ apply s t
+  pure $ apply s t
 
 generalize :: TypeEnv -> Type -> Scheme
 generalize env t  = Forall as t
-    where as = Set.toList $ ftv t `Set.difference` ftv env
+    where as = Set.toUnfoldable $ ftv t `Set.difference` ftv env
 
 runInfer :: Infer (Tuple Subst Type) -> Either TypeError Scheme
 runInfer m = case evalState (runExceptT m) initUnique of
@@ -228,13 +231,13 @@ emptyTyenv = TypeEnv Map.empty
 overlappingBindings :: List Binding -> List String
 overlappingBindings Nil = Nil
 overlappingBindings (Cons x Nil) = Nil
-overlappingBindings (Cons x xs) = (filter (\y -> elem y (concatMap boundNames xs)) (boundNames x)) ++ overlappingBindings xs
+overlappingBindings (Cons x xs) = (filter (\y -> elem y (concatMap boundNames xs)) (boundNames x)) <> overlappingBindings xs
   where
     boundNames :: Binding -> (List String)
     boundNames = go
       where
       go (Lit (Name name)) = singleton name
-      go (ConsLit b1 b2)   = go b1 ++ go b2
+      go (ConsLit b1 b2)   = go b1 <> go b2
       go (ListLit bs)      = foldMap go bs
       go (NTupleLit bs)    = foldMap go bs
       go _                 = Nil
@@ -242,12 +245,12 @@ overlappingBindings (Cons x xs) = (filter (\y -> elem y (concatMap boundNames xs
 -- TODO find Purescript equivalents
 ------------------------------------------------------------------------------------
 mapM :: forall a b m. (Monad m) => (a -> m b) -> List a -> m (List b)
-mapM f as = foldr k (return Nil) as
+mapM f as = foldr k (pure Nil) as
             where
               k a r = do
                 x <- f a
                 xs <- r
-                return (x:xs)
+                pure (x:xs)
 
 mapM' :: forall a b m. (Monad m) => (a -> m b) -> Maybe a -> m (Maybe b)
 mapM' f Nothing  = pure Nothing
@@ -264,7 +267,7 @@ lookupEnv (TypeEnv env) x = do
   case Map.lookup x env of
     Nothing -> throwError $ UnboundVariable (f x)
     Just s  -> do t <- instantiate s
-                  return (Tuple nullSubst t)
+                  pure (Tuple nullSubst t)
   where
     f (Name x) = x
     f x = show x
@@ -273,7 +276,7 @@ inferType :: TypeEnv -> Expr -> Infer (Tuple Subst Type)
 inferType env exp = do
   Tuple s t <- infer env exp
   let t' = extractType t
-  return $ Tuple s t'
+  pure $ Tuple s t'
 
 data InferResult a = InferResult {subst :: Subst, envi :: TypeEnv, result :: a}
 
@@ -285,43 +288,43 @@ inferBinding env bin e1 = do
   let env' = apply (s1 `compose` s2) env
       t'   = generalize env' (apply (s1 `compose` s2) (extractType t1))
       env'' = apply s2 (foldr (\a b -> extend b a) env' list)
-  return $ InferResult {subst: s2, envi: env'', result: (Tuple typ t1)}
+  pure $ InferResult {subst: s2, envi: env'', result: (Tuple typ t1)}
 
 inferBindings :: TypeEnv -> List (Tuple Binding Expr) -> Infer (InferResult (List (Tuple TypeBinding TypeTree)))
 inferBindings _ Nil = throwError $ UnknownError "congrats you found a bug TypeChecker.inferBindings"
 inferBindings env (Cons (Tuple bin expr) Nil) = do
   InferResult {subst: s, envi: e, result: r} <- inferBinding env bin expr
-  return $ InferResult {subst: s, envi: e, result: (pure r)}
+  pure $ InferResult {subst: s, envi: e, result: (pure r)}
 inferBindings env (Cons (Tuple bin expr) rest) = do
   InferResult {subst: s, envi: e, result: res}    <- inferBinding env bin expr
   InferResult {subst: sr, envi: er, result: resr} <- inferBindings e rest
   let sRes = s `compose` sr
-  return $ InferResult {subst: sRes, envi: er, result: (Cons res resr)}
+  pure $ InferResult {subst: sRes, envi: er, result: (Cons res resr)}
 
 infer :: TypeEnv -> Expr -> Infer (Tuple Subst TypeTree)
 infer env ex = case ex of
 
   (Atom x@(Name n)) -> case n of
-    "mod" -> return $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
-    "div" -> return $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
+    "mod" -> pure $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
+    "div" -> pure $ Tuple nullSubst (TAtom (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int")))
     _     -> do
       Tuple s t <- lookupEnv env x
-      return (Tuple s $ TAtom t)
-  (Atom (Bool _)) -> return (Tuple nullSubst $ TAtom (TypCon "Bool"))
-  (Atom (Char _)) -> return (Tuple nullSubst $ TAtom (TypCon "Char"))
-  (Atom (AInt _)) -> return (Tuple nullSubst $ TAtom (TypCon "Int"))
+      pure (Tuple s $ TAtom t)
+  (Atom (Bool _)) -> pure (Tuple nullSubst $ TAtom (TypCon "Bool"))
+  (Atom (Char _)) -> pure (Tuple nullSubst $ TAtom (TypCon "Char"))
+  (Atom (AInt _)) -> pure (Tuple nullSubst $ TAtom (TypCon "Int"))
 
   Lambda (Cons bin Nil) e -> do
     Tuple envL tvB <- extractBinding bin
     let env' = foldr (\a b -> extend b a) env envL
     (Tuple s1 t1) <- infer env' e
-    return (Tuple s1 $ apply s1 (TLambda (Cons tvB Nil) t1 $ (extractBindingType tvB) `TypArr` (extractType t1)))
+    pure (Tuple s1 $ apply s1 (TLambda (Cons tvB Nil) t1 $ (extractBindingType tvB) `TypArr` (extractType t1)))
 
   Lambda (Cons bin xs) e -> do
     Tuple envL tvB <- extractBinding bin
     let env' = foldr (\a b -> extend b a) env envL
     (Tuple s1 (TLambda tb tt t1)) <- infer env' (Lambda xs e)
-    return (Tuple s1 $ apply s1 (TLambda (Cons tvB tb) tt ((extractBindingType tvB) `TypArr` t1)))
+    pure (Tuple s1 $ apply s1 (TLambda (Cons tvB tb) tt ((extractBindingType tvB) `TypArr` t1)))
 
   Lambda Nil e -> infer env e
 
@@ -331,11 +334,11 @@ infer env ex = case ex of
     (Tuple s1 t1) <- infer env e1
     (Tuple s2 t2) <- infer (apply s1 env) e2
     s3       <- unify (apply (s1  `compose` s2) (extractType t1)) (TypArr (extractType t2) tv)
-    return (Tuple (s3 `compose` s2 `compose` s1) (apply s3 $ TApp t1 (Cons t2 Nil) tv))
+    pure (Tuple (s3 `compose` s2 `compose` s1) (apply s3 $ TApp t1 (Cons t2 Nil) tv))
 
   App e1 (Cons e2 xs) -> do
     Tuple s (TApp (TApp tt lt _) lt' t') <- infer env  (App (App e1 (Cons e2 Nil)) xs)
-    return $ Tuple s (TApp tt (lt++lt') t')
+    pure $ Tuple s (TApp tt (lt<>lt') t')
 
   App _ Nil -> throwError $ UnknownError "congrats you found a bug TypeChecker.infer (App Nil)"
 
@@ -344,23 +347,23 @@ infer env ex = case ex of
     --let env' = apply sq env
     Tuple s t <- infer env' expr
     let s' = sq `compose` s
-    return $ Tuple s' $ apply s' $ TListComp t tq (AD (TList (extractType t)))
+    pure $ Tuple s' $ apply s' $ TListComp t tq (AD (TList (extractType t)))
 
   LetExpr bindings expr -> case overlappingBindings (fst <$> bindings) of
-    (Cons x _) -> throwError $ UnknownError $ "Conflicting definitions for \'" ++ x ++ "\'"
+    (Cons x _) -> throwError $ UnknownError $ "Conflicting definitions for \'" <> x <> "\'"
     Nil        -> do
       InferResult {subst: sb, envi: envb, result: resb} <- inferBindings env bindings
       Tuple se te <- infer envb expr
       let s = sb `compose` se
-      return $ Tuple s $ apply s $ TLetExpr resb te (extractType te)
+      pure $ Tuple s $ apply s $ TLetExpr resb te (extractType te)
 
   IfExpr cond tr fl -> do
     tv <- fresh
     t@(TypVar t') <- fresh
     let name = Name $ "if"
     let env' = env `extend` (Tuple name (Forall (Cons t' Nil) (TypArr (TypCon "Bool") (TypArr t (TypArr t  t)))))
-    Tuple s (TApp tt (Cons tcond (Cons ttr (Cons tfl Nil))) ift) <- infer env' (App (Atom  name) (toList [cond, tr, fl]))
-    return (Tuple s $ apply s (TIfExpr tcond ttr tfl ift))
+    Tuple s (TApp tt (Cons tcond (Cons ttr (Cons tfl Nil))) ift) <- infer env' (App (Atom  name) (toUnfoldable [cond, tr, fl]))
+    pure (Tuple s $ apply s (TIfExpr tcond ttr tfl ift))
 
   ArithmSeq begin jstep jend -> do
     Tuple s1 t1 <- infer env begin
@@ -373,76 +376,76 @@ infer env ex = case ex of
     let s  = s1 `compose` s2 `compose` s3
     let tt = extractType t1   
     let typeMissMatch t1 t2 = fromMaybe (UnknownError "congrats you found a bug TypeChecker.infer (ArithmSeq begin jstep jend)") (lift2 UnificationFail t1 t2)
-    ifM (return (fromMaybe false (lift2 (/=) (Just tt) (extractType <$> t2))))
+    ifM (pure (fromMaybe false (lift2 (/=) (Just tt) (extractType <$> t2))))
       (throwError (typeMissMatch (Just tt) (extractType <$> t2)))
-      (ifM (return (fromMaybe false (lift2 (/=) (Just tt) (extractType <$> t3))))
+      (ifM (pure (fromMaybe false (lift2 (/=) (Just tt) (extractType <$> t3))))
         (throwError (typeMissMatch (Just tt) (extractType <$> t3)))
-        (ifM (return (fromMaybe false (lift2 (/=) (extractType <$> t2) (extractType <$> t3))))
+        (ifM (pure (fromMaybe false (lift2 (/=) (extractType <$> t2) (extractType <$> t3))))
           (throwError (typeMissMatch (extractType <$> t2) (extractType <$> t3)))
           (case tt of
-            TypCon "Int"  -> return $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
-            TypCon "Bool" -> return $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
-            TypCon "Char" -> return $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
+            TypCon "Int"  -> pure $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
+            TypCon "Bool" -> pure $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
+            TypCon "Char" -> pure $ Tuple s $ apply s $ TArithmSeq t1 t2 t3 (AD (TList tt))
             _             -> throwError $ NoInstanceOfEnum tt)))
 
   PrefixOp op -> do
     Tuple s t <- inferOp env op
-    return (Tuple s $ TPrefixOp t)
+    pure (Tuple s $ TPrefixOp t)
 
   SectL e op -> do
     tv <- fresh
     (Tuple s1 t1) <- inferOp env op
     (Tuple s2 t2) <- infer (apply s1 env) e
     s3       <- unify (apply s2 t1) (TypArr (extractType t2) tv)
-    return (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TSectL t2 t1 tv)))
+    pure (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TSectL t2 t1 tv)))
 
   SectR op e -> do
     (Tuple s1 t1@(TypArr a (TypArr b c))) <- inferOp env op
     (Tuple s2 t2) <- infer env e
     s3       <- unify (apply s2 b) (extractType t2)
     let s4 = (s3 `compose` s2 `compose` s1)
-    return (Tuple s4 (apply s4 (TSectR t1 t2 (TypArr a c))))
+    pure (Tuple s4 (apply s4 (TSectR t1 t2 (TypArr a c))))
 
   Unary (Sub) e -> do
       tv <- fresh
       let t1 = (TypCon "Int" `TypArr` TypCon "Int")
       (Tuple s2 t2) <- infer env e
       s3       <- unify (apply s2 t1) (TypArr (extractType t2) tv)
-      return (Tuple (s3 `compose` s2) (apply s3 (TUnary t1 t2 tv)))
+      pure (Tuple (s3 `compose` s2) (apply s3 (TUnary t1 t2 tv)))
 
   Unary op e -> do
     tv <- fresh
     (Tuple s1 t1) <- inferOp env op
     (Tuple s2 t2) <- infer (apply s1 env) e
     s3       <- unify (apply s2 t1) (TypArr (extractType t2) tv)
-    return (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TUnary t1 t2 tv)))
+    pure (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TUnary t1 t2 tv)))
 
   Binary op e1 e2 -> do
     (Tuple s (TApp tt (Cons tt1 (Cons tt2 Nil)) t)) <- infer env (App (PrefixOp op) (Cons e1 (Cons e2 Nil)))
-    return $ Tuple s (TBinary (extractType tt) tt1 tt2 t)
+    pure $ Tuple s (TBinary (extractType tt) tt1 tt2 t)
 
   List (Cons e1 xs) -> do
     (Tuple s1 (TListTree ltt (AD (TList t1)))) <- infer env (List xs)
     (Tuple s2 t2) <- infer (apply s1 env) e1
     s3 <- unify (apply s2 t1) (extractType t2)
-    return (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TListTree (Cons t2 ltt) (AD $ TList (extractType t2)))))
+    pure (Tuple (s3 `compose` s2 `compose` s1) (apply s3 (TListTree (Cons t2 ltt) (AD $ TList (extractType t2)))))
 
   List Nil -> do
     tv <- fresh
-    return (Tuple nullSubst $ TListTree Nil (AD $ TList tv))
+    pure (Tuple nullSubst $ TListTree Nil (AD $ TList tv))
 
   NTuple (Cons e Nil) -> do
     (Tuple s t) <- infer env e
-    return $ Tuple s $ TNTuple (Cons t Nil) (AD $ TTuple $ Cons (extractType t) Nil)
+    pure $ Tuple s $ TNTuple (Cons t Nil) (AD $ TTuple $ Cons (extractType t) Nil)
 
   NTuple (Cons e1 xs) -> do
     (Tuple s1 (TNTuple lt (AD (TTuple t1)))) <- infer env (NTuple xs)
     (Tuple s2 t2) <- infer (apply s1 env) e1
-    return (Tuple (s2 `compose` s1) $ TNTuple (Cons t2 lt) (AD $ TTuple (Cons (extractType t2) t1)))
+    pure (Tuple (s2 `compose` s1) $ TNTuple (Cons t2 lt) (AD $ TTuple (Cons (extractType t2) t1)))
 
   NTuple Nil -> throwError $ UnknownError "congrats you found a bug in TypeChecker.infer (NTuple Nil)"
 
-  x -> throwError $ UnknownError $ "Error in TypeChecker.infer: unknown case: " ++ show x 
+  x -> throwError $ UnknownError $ "Error in TypeChecker.infer: unknown case: " <> show x
 
 inferQual :: TypeEnv -> ExprQual -> Infer (Tuple Subst (Tuple TypeQual TypeEnv))
 inferQual env (Let bin e1) = do
@@ -451,7 +454,7 @@ inferQual env (Let bin e1) = do
   s2   <- unify (extractBindingType typ) (extractType t1)
   let env' = apply s2 (foldr (\a b -> extend b a) env list)
   let sC = s1 `compose` s2
-  return $ Tuple sC $ Tuple (apply sC (TLet typ t1 (extractType t1))) env'
+  pure $ Tuple sC $ Tuple (apply sC (TLet typ t1 (extractType t1))) env'
 inferQual env (Gen bin e1) = do 
   (Tuple s1 t1) <- infer env e1 
   case extractType t1 of 
@@ -460,21 +463,21 @@ inferQual env (Gen bin e1) = do
       s2 <- unify (extractBindingType typ) t
       let env' = apply s2 (foldr (\a b -> extend b a) env list)      
       let sC = s1 `compose` s2
-      return $ Tuple sC $ Tuple (apply sC (TGen typ t1 t)) env'
+      pure $ Tuple sC $ Tuple (apply sC (TGen typ t1 t)) env'
     _ -> fresh >>= (\t -> throwError $ UnificationFail (extractType t1) (AD (TList t)))
 inferQual env (Guard expr) = do
   Tuple s t <- infer env expr
   case extractType t of
-    TypCon "Bool" -> return $ Tuple s $ Tuple (apply s (TGuard t (extractType t))) env
+    TypCon "Bool" -> pure $ Tuple s $ Tuple (apply s (TGuard t (extractType t))) env
     _             -> throwError $ UnificationFail (extractType t) (TypCon "Bool")
 
 inferQuals :: TypeEnv -> List ExprQual -> Infer (Tuple Subst (Tuple (List TypeQual) TypeEnv))
-inferQuals env Nil = return $ Tuple nullSubst $ Tuple Nil emptyTyenv
+inferQuals env Nil = pure $ Tuple nullSubst $ Tuple Nil emptyTyenv
 inferQuals env (Cons x rest) = do
   Tuple s  (Tuple t  env1) <- inferQual env x
   Tuple sr (Tuple tr env2) <- inferQuals (apply s env1) rest
   let s' = s `compose` sr
-  return $ Tuple s' $ Tuple (t `Cons` tr) (envUnion env2 env1)
+  pure $ Tuple s' $ Tuple (t `Cons` tr) (envUnion env2 env1)
 
 inferOp :: TypeEnv -> Op -> Infer (Tuple Subst Type)
 inferOp env op = do
@@ -501,7 +504,7 @@ inferOp env op = do
     Dollar -> f ((a `TypArr` b) `TypArr` (a `TypArr` b))
     InfixFunc name -> inferType env (Atom (Name name))
  where
-  f typ = return (Tuple nullSubst typ)
+  f typ = pure (Tuple nullSubst typ)
   int3 = f (TypCon "Int" `TypArr` (TypCon "Int" `TypArr` TypCon "Int"))
   aBool a = f (a `TypArr` (a `TypArr` TypCon "Bool"))
 
@@ -515,7 +518,7 @@ inferDef env (Def str bin exp) = do
     let env'' = env `extend` (Tuple (Name str) (Forall Nil (apply s1 t1)))
     Tuple s2 t2 <- infer env'' exp'
     s3 <- unify (apply s1 t1) (apply s2 (extractType t2))
-    return $ Tuple (s3 `compose` s1) (apply s3 (apply s1 t1))
+    pure $ Tuple (s3 `compose` s1) (apply s3 (apply s1 t1))
 
 
 extractConsLit:: Type -> Binding -> Infer (Tuple (List (Tuple Atom Scheme)) TypeBinding)
@@ -524,21 +527,21 @@ extractConsLit tv (ConsLit a b@(ConsLit _ _)) = do
   Tuple list2 t2@(TConsLit b1 b2 (AD (TList typ2))) <- extractBinding b
   s1 <- unify tv (extractBindingType typ1)
   s2 <- unify (apply s1 tv) (typ2)
-  return $ Tuple (apply s2 (apply s1 (list1 ++ list2))) (apply s2 (apply s1 (TConsLit typ1 t2 (AD $ TList typ2))))
+  pure $ Tuple (apply s2 (apply s1 (list1 <> list2))) (apply s2 (apply s1 (TConsLit typ1 t2 (AD $ TList typ2))))
 
 extractConsLit tv (ConsLit a (Lit b)) = do
   Tuple list typ <- extractBinding a
   s1 <- unify tv (extractBindingType typ)
   let list' = apply s1 list
   let ltyp = AD $ TList (apply s1 tv)
-  return $ Tuple (Cons (Tuple b $ Forall Nil ltyp) list') $ (apply s1 (TConsLit typ (TLit ltyp) ltyp))
+  pure $ Tuple (Cons (Tuple b $ Forall Nil ltyp) list') $ (apply s1 (TConsLit typ (TLit ltyp) ltyp))
 
 extractConsLit tv (ConsLit a b@(ListLit _)) = do
   Tuple list1 typ1 <- extractBinding a
   Tuple list2 t2@(TListLit b1 (AD (TList typ2))) <- extractBinding b
   s1 <- unify tv (extractBindingType typ1)
   s2 <- unify (apply s1 tv) (typ2)
-  return $ Tuple (apply s2 (apply s1 (list1 ++ list2))) (apply s2 (apply s1 (TConsLit typ1 t2 (AD $ TList typ2))))
+  pure $ Tuple (apply s2 (apply s1 (list1 <> list2))) (apply s2 (apply s1 (TConsLit typ1 t2 (AD $ TList typ2))))
 
 extractConsLit _ _ = throwError $ UnknownError "congrats you found a bug in TypeChecker.extractConsLit"
 
@@ -546,22 +549,22 @@ extractConsLit _ _ = throwError $ UnknownError "congrats you found a bug in Type
 extractListLit :: List Binding -> Infer (List (Tuple (List (Tuple Atom Scheme)) TypeBinding))
 extractListLit (Cons a Nil) = do
   b1 <- extractBinding a
-  return (Cons b1 Nil)
+  pure (Cons b1 Nil)
 
 extractListLit (Cons a b) = do
   b1 <- extractBinding a
   bs <- extractListLit b
-  return (Cons b1 bs)
+  pure (Cons b1 bs)
 
-extractListLit Nil = return Nil
+extractListLit Nil = pure Nil
 
 extractBinding:: Binding -> Infer (Tuple (List (Tuple Atom Scheme)) TypeBinding)
 extractBinding (Lit a@(Name _)) = do
   tv <- fresh
-  return $ Tuple (toList [(Tuple a (Forall Nil tv))]) (TLit tv)
-extractBinding (Lit (Bool _)) = return $ Tuple Nil $ TLit (TypCon "Bool")
-extractBinding (Lit (Char _)) = return $ Tuple Nil $ TLit (TypCon "Char")
-extractBinding (Lit (AInt _)) = return $ Tuple Nil $ TLit (TypCon "Int")
+  pure $ Tuple (toUnfoldable [(Tuple a (Forall Nil tv))]) (TLit tv)
+extractBinding (Lit (Bool _)) = pure $ Tuple Nil $ TLit (TypCon "Bool")
+extractBinding (Lit (Char _)) = pure $ Tuple Nil $ TLit (TypCon "Char")
+extractBinding (Lit (AInt _)) = pure $ Tuple Nil $ TLit (TypCon "Int")
 
 extractBinding a@(ConsLit _ _) = do
   tv <- fresh
@@ -572,21 +575,21 @@ extractBinding (ListLit a) = do -- Tuple TypEnv  (TListLit (List TypeBinding) Ty
   tv <- fresh
   let ini = Tuple Nil (TListLit Nil tv)
   Tuple list (TListLit lb typ) <- foldM f ini bs
-  return $ Tuple list (TListLit lb (AD $ TList typ))
+  pure $ Tuple list (TListLit lb (AD $ TList typ))
   where
 -- :: Tuple (List (Tuple Atom Scheme)) BindingType -> Tuple (List (Tuple Atom Scheme)) BindingType
 --           -> Infer (Tuple (List (Tuple Atom Scheme)) BindingType)
     f (Tuple l1 (TListLit lb1 t1)) (Tuple l2 b) = do
-      let ls = l1 ++ l2
+      let ls = l1 <> l2
       s1 <- unify t1 (extractBindingType b)
-      return $ Tuple (apply s1 ls) (apply s1 (TListLit (Cons b lb1) t1))
+      pure $ Tuple (apply s1 ls) (apply s1 (TListLit (Cons b lb1) t1))
     f _ _ = throwError $ UnknownError "congrats you found a bug in TypeChecker.extractBinding"
 
 
 extractBinding (NTupleLit a) = do
   bs <- extractListLit a
   let tup = unzip bs
-  return $ Tuple (concat $ fst tup) (TNTupleLit (snd tup) (AD $ TTuple $ (map extractBindingType (snd tup))))
+  pure $ Tuple (concat $ fst tup) (TNTupleLit (snd tup) (AD $ TTuple $ (map extractBindingType (snd tup))))
 
 
 getTypEnv:: Binding -> TypeEnv -> Maybe TypeEnv
@@ -597,7 +600,7 @@ getTypEnv b  env= case evalState (runExceptT (extractBinding b)) initUnique of
 getTypEnvFromList::  List Binding -> TypeEnv-> Maybe TypeEnv
 getTypEnvFromList bs env = do
                   mTypList <-  mapM (flip getTypEnv emptyTyenv) bs
-                  return $ foldr (\a b -> unionTypeEnv a b) env mTypList
+                  pure $ foldr (\a b -> unionTypeEnv a b) env mTypList
 
 unionTypeEnv :: TypeEnv -> TypeEnv -> TypeEnv
 unionTypeEnv (TypeEnv a) (TypeEnv b) = TypeEnv (Map.union a b)
@@ -609,7 +612,7 @@ inferGroup env (Cons def1 defs) = do
   Tuple s1 t1 <- inferDef env def1
   Tuple s2 t2 <- inferGroup env defs
   s3 <- unify t1 t2
-  return $ Tuple s3 (apply s3 t1)
+  pure $ Tuple s3 (apply s3 t1)
 
 
 buildTypeEnv:: List Definition -> Either TypeError TypeEnv
@@ -676,15 +679,15 @@ closeOver' (Tuple s tt) = apply s tt
 prettyPrintType:: Type -> String
 prettyPrintType (TypVar (TVar a)) = a
 prettyPrintType (TypCon a) =  a
-prettyPrintType (TypArr t1@(TypArr _ _) t2) = "(" ++ prettyPrintType t1 ++ ")" ++ " -> " ++ prettyPrintType t2
-prettyPrintType (TypArr t1 t2) = prettyPrintType t1 ++ " -> " ++ prettyPrintType t2
+prettyPrintType (TypArr t1@(TypArr _ _) t2) = "(" <> prettyPrintType t1 <> ")" <> " -> " <> prettyPrintType t2
+prettyPrintType (TypArr t1 t2) = prettyPrintType t1 <> " -> " <> prettyPrintType t2
 prettyPrintType (AD a) = prettyPrintAD a
 prettyPrintType (TypeError a) = prettyPrintTypeError a
 
 
 prettyPrintAD:: AD -> String
-prettyPrintAD (TList a) = "[" ++ prettyPrintType a ++ "]"
-prettyPrintAD (TTuple (Cons t1 a)) = foldl (\s t -> s ++ "," ++ prettyPrintType t) ("(" ++ prettyPrintType t1 ) a  ++ ")"
+prettyPrintAD (TList a) = "[" <> prettyPrintType a <> "]"
+prettyPrintAD (TTuple (Cons t1 a)) = foldl (\s t -> s <> "," <> prettyPrintType t) ("(" <> prettyPrintType t1 ) a  <> ")"
 prettyPrintAD (TTuple Nil) = "()"
 
 emptyType:: Type
@@ -780,69 +783,69 @@ txToABC tt = fst $ runState (helptxToABC tt) {count : 0, env : empty}
 helptxToABC:: TypeTree -> State {count:: Int, env:: Map String String} TypeTree
 helptxToABC tt = go tt
   where
-    go (TAtom t) = helpTypeToABC t >>= \t -> return $ TAtom t
+    go (TAtom t) = helpTypeToABC t >>= \t -> pure $ TAtom t
     go (TListTree tts t) = do
       tts' <- mapM helptxToABC tts
       t' <- helpTypeToABC t
-      return $ TListTree tts' t'
+      pure $ TListTree tts' t'
     go (TNTuple tts t) = do
       tts' <- mapM helptxToABC tts
       t' <- helpTypeToABC t
-      return $ TNTuple tts' t'
+      pure $ TNTuple tts' t'
     go (TBinary t1 tt1 tt2 t) = do
       t1' <- helpTypeToABC t1
       tt1' <- helptxToABC tt1
       tt2' <- helptxToABC tt2
       t' <- helpTypeToABC t
-      return $ TBinary t1' tt1' tt2' t'
+      pure $ TBinary t1' tt1' tt2' t'
     go (TUnary t1 tt t) = do
       t1' <- helpTypeToABC t1
       tt' <- helptxToABC tt
       t' <- helpTypeToABC t
-      return $ (TUnary t1' tt' t')
+      pure $ (TUnary t1' tt' t')
     go (TSectL tt t1 t) = do
       t1' <- helpTypeToABC t1
       tt' <- helptxToABC tt
       t' <- helpTypeToABC t
-      return $ TSectL tt' t1' t'
+      pure $ TSectL tt' t1' t'
     go (TSectR t1 tt t) = do
       t1' <- helpTypeToABC t1
       tt' <- helptxToABC tt
       t' <- helpTypeToABC t
-      return $ TSectR t1' tt' t'
-    go (TPrefixOp t) = helpTypeToABC t >>= \t -> return $ TPrefixOp t
+      pure $ TSectR t1' tt' t'
+    go (TPrefixOp t) = helpTypeToABC t >>= \t -> pure $ TPrefixOp t
     go (TIfExpr tt1 tt2 tt3 t) = do
       tt1' <- helptxToABC tt1
       tt2' <- helptxToABC tt2
       tt3' <- helptxToABC tt3
       t' <- helpTypeToABC t
-      return $ TIfExpr tt1' tt2' tt3' t'
+      pure $ TIfExpr tt1' tt2' tt3' t'
     go (TArithmSeq tt1 tt2 tt3 t) = do
       tt1' <- helptxToABC tt1
       tt2' <- mapM' helptxToABC tt2
       tt3' <- mapM' helptxToABC tt3
       t'   <- helpTypeToABC t
-      return $ TArithmSeq tt1' tt2' tt3' t'        
+      pure $ TArithmSeq tt1' tt2' tt3' t'
     go (TLetExpr bin tt t) = do
       bin' <- mapM (\(Tuple x y) -> lift2 Tuple (helpBindingToABC x) (helptxToABC y)) bin
       tt'  <- helptxToABC tt
       t'   <- helpTypeToABC t
-      return $ TLetExpr bin' tt' t'
+      pure $ TLetExpr bin' tt' t'
     go (TLambda tbs tt t) = do
       tbs' <- mapM helpBindingToABC tbs
       tt' <- helptxToABC tt
       t' <- helpTypeToABC t
-      return $ TLambda tbs' tt' t'
+      pure $ TLambda tbs' tt' t'
     go (TApp tt tts t) = do
       tt' <- helptxToABC tt
       tts' <- mapM helptxToABC tts
       t' <- helpTypeToABC t
-      return $ TApp tt' tts' t'
+      pure $ TApp tt' tts' t'
     go (TListComp tt tts t) = do
       tt'  <- helptxToABC tt
       tts' <- mapM helptxToABCQual tts
       t'   <- helpTypeToABC t
-      return $ TListComp tt' tts' t'      
+      pure $ TListComp tt' tts' t'
 
 typeToABC:: Type -> Type
 typeToABC t = fst $ runState (helpTypeToABC t) {count: 0, env: empty}
@@ -853,107 +856,109 @@ helptxToABCQual q = case q of
     b' <- helpBindingToABC b
     e' <- helptxToABC e
     t' <- helpTypeToABC t
-    return $ TGen b' e' t'
+    pure $ TGen b' e' t'
   TLet b e t -> do
     b' <- helpBindingToABC b
     e' <- helptxToABC e
     t' <- helpTypeToABC t
-    return $ TLet b' e' t'
+    pure $ TLet b' e' t'
   TGuard e t -> do
     e' <- helptxToABC e
     t' <- helpTypeToABC t
-    return $ TGuard e' t'
+    pure $ TGuard e' t'
 
 helpTypeToABC:: Type  -> State {count :: Int, env:: (Map String String)} Type
 helpTypeToABC t = go t
   where
    go (TypVar (TVar var)) = do
-      {env: (env :: Map String String)} <- get
+      {count: count, env: env} :: {count:: Int, env:: Map String String} <- get
       case lookup var env of
-        Just var' -> return $ TypVar (TVar var')
+        Just var' -> pure $ TypVar (TVar var')
         Nothing -> do
           var' <- freshLetter
           let env' = (insert var var' env)
-          {count: (count :: Int)} <- get
+          {count: count, env: env} :: {count:: Int, env:: Map String String} <- get
           put {count:count, env:env'}
-          return $ TypVar (TVar var')
+          pure $ TypVar (TVar var')
    go (TypArr t1 t2) = do
         t1' <- helpTypeToABC t1
         t2' <- helpTypeToABC t2
-        return $ TypArr t1' t2'
-   go (AD a) = helpADTypeToABC a >>= \a -> return $ AD a
-   go a = return a
+        pure $ TypArr t1' t2'
+   go (AD a) = helpADTypeToABC a >>= \a -> pure $ AD a
+   go a = pure a
 
 helpADTypeToABC:: AD -> State {count :: Int, env:: (Map String String)} AD
-helpADTypeToABC (TList t) = helpTypeToABC t >>= \t -> return $ TList t
-helpADTypeToABC (TTuple ts) = mapM helpTypeToABC ts >>= \ts -> return $ TTuple ts
+helpADTypeToABC (TList t) = helpTypeToABC t >>= \t -> pure $ TList t
+helpADTypeToABC (TTuple ts) = mapM helpTypeToABC ts >>= \ts -> pure $ TTuple ts
 
 helpBindingToABC:: TypeBinding -> State {count :: Int, env:: (Map String String)} TypeBinding
 helpBindingToABC bin = go bin
   where
-    go (TLit t) = helpTypeToABC t >>= \t ->return $ TLit t
+    go (TLit t) = helpTypeToABC t >>= \t ->pure $ TLit t
     go (TConsLit tb1 tb2 t) = do
       tb1' <- helpBindingToABC tb1
       tb2' <- helpBindingToABC tb2
       t' <- helpTypeToABC t
-      return $ TConsLit tb1' tb2' t'
+      pure $ TConsLit tb1' tb2' t'
     go (TListLit tbs t) = do
       tbs' <- mapM helpBindingToABC tbs
       t' <- helpTypeToABC t
-      return $ TListLit tbs' t'
+      pure $ TListLit tbs' t'
     go (TNTupleLit tbs t) = do
       tbs' <- mapM helpBindingToABC tbs
       t' <- helpTypeToABC t
-      return $ TNTupleLit tbs' t'
+      pure $ TNTupleLit tbs' t'
 
 freshLetter:: State {count:: Int, env:: Map String String} String
 freshLetter = do
-    {count: count, env: env :: Map String String} <- get
+    {count: count, env: env} :: {count:: Int, env:: Map String String} <- get
     put {count:count+1, env:env}
-    return $ fromCharList $ newTypVar count
-
+    pure $ charListToString (newTypVar count)
+    where
+      charListToString :: List Char -> String
+      charListToString xs = fromCharArray (Array.fromFoldable xs)
 
 letters:: List Char
-letters = (toList $ toCharArray "abcdefghijklmnopqrstuvwxyz")
+letters = (toUnfoldable $ toCharArray "abcdefghijklmnopqrstuvwxyz")
 
 letters1:: List Char
-letters1 = (toList $ toCharArray " abcdefghijklmnopqrstuvwxyz")
+letters1 = (toUnfoldable $ toCharArray " abcdefghijklmnopqrstuvwxyz")
 
 newTypVar:: Int -> List Char
 newTypVar i = case (letters !! i) of
   Just c ->  Cons c Nil
-  Nothing -> let i1 = (i `div` 26) in let i2 = (i `mod` 26) in (newTypVar1 i1) ++ (newTypVar i2)
+  Nothing -> let i1 = (i `div` 26) in let i2 = (i `mod` 26) in (newTypVar1 i1) <> (newTypVar i2)
 
 -- workaround
 -- if i  subtract one from i => stack overflow at ~50
 newTypVar1:: Int -> List Char
 newTypVar1 i = case (letters1 !! (i)) of
   Just c ->  Cons c Nil
-  Nothing -> let i1 = (i `div` 26) in let i2 = (i `mod` 26) in (newTypVar1 i1) ++ (newTypVar i2)
-
-
+  Nothing -> let i1 = (i `div` 26) in let i2 = (i `mod` 26) in (newTypVar1 i1) <> (newTypVar i2)
 
 prettyPrintTypeError:: TypeError -> String
-prettyPrintTypeError (UnificationFail t1 t2) = let t1t2 = twoTypesToABC t1 t2  in
+prettyPrintTypeError (UnificationFail t1 t2) = let t1t2 = twoTypesToABC t1 t2 in
                                                 "UnificationFail: Can't unify "
-                                                ++ prettyPrintType (fst t1t2) ++ " with "
-                                                ++ prettyPrintType (snd t1t2)
+                                                <> prettyPrintType (fst t1t2) <> " with "
+                                                <> prettyPrintType (snd t1t2)
 prettyPrintTypeError (InfiniteType a b) = let ab = twoTypesToABC (TypVar a) b in
                                               "InfiniteType: cannot construct the infinite type: "
-                                              ++ prettyPrintType (fst ab)++ " ~ "
-                                              ++ prettyPrintType (snd ab)
+                                              <> prettyPrintType (fst ab)<> " ~ "
+                                              <> prettyPrintType (snd ab)
 prettyPrintTypeError (UnboundVariable var) = "UnboundVariable: Not in scope "
-                                              ++ var
+                                              <> var
 prettyPrintTypeError (UnificationMismatch ts1 ts2) = let ts1ts2 = twoTypeListsToABC ts1 ts2 in
-    "UnificationMismatch: " ++ toStr (fst ts1ts2) ++ " " ++ toStr (snd ts1ts2)
+    "UnificationMismatch: " <> toStr (fst ts1ts2) <> " " <> toStr (snd ts1ts2)
   where
-    toStr ts = "[" ++ (foldr (\t s -> t ++ "," ++ s) "]" (map (\a -> prettyPrintType (typeToABC a)) ts))
-prettyPrintTypeError (UnknownError str) = "UnknownError: " ++ str
+    toStr ts = "[" <> (foldr (\t s -> t <> "," <> s) "]" (map (\a -> prettyPrintType (typeToABC a)) ts))
+prettyPrintTypeError (UnknownError str) = "UnknownError: " <> str
 prettyPrintTypeError defaultCase = show defaultCase
 
+twoTypesToABC :: Type -> Type -> Tuple Type Type
 twoTypesToABC t1 t2 = (\(TypArr t1' t2') -> Tuple t1' t2') (typeToABC (TypArr t1 t2))
-twoTypeListsToABC t1 t2 = (\(TypArr (AD (TTuple t1')) (AD (TTuple t2'))) -> Tuple t1' t2') (typeToABC (TypArr (AD (TTuple t1)) (AD (TTuple t2)) ))
 
+twoTypeListsToABC :: (List Type) -> (List Type) -> Tuple (List Type) (List Type)
+twoTypeListsToABC t1 t2 = (\(TypArr (AD (TTuple t1')) (AD (TTuple t2'))) -> Tuple t1' t2') (typeToABC (TypArr (AD (TTuple t1)) (AD (TTuple t2)) ))
 
 checkForError:: Path -> TypeTree -> Boolean
 checkForError p' tt = case p' of

--- a/src/TypeChecker.purs
+++ b/src/TypeChecker.purs
@@ -868,13 +868,13 @@ helpTypeToABC:: Type  -> State {count :: Int, env:: (Map String String)} Type
 helpTypeToABC t = go t
   where
    go (TypVar (TVar var)) = do
-      {env = env :: Map String String} <- get
+      {env: (env :: Map String String)} <- get
       case lookup var env of
         Just var' -> return $ TypVar (TVar var')
         Nothing -> do
           var' <- freshLetter
           let env' = (insert var var' env)
-          {count=count:: Int} <- get
+          {count: (count :: Int)} <- get
           put {count:count, env:env'}
           return $ TypVar (TVar var')
    go (TypArr t1 t2) = do
@@ -908,7 +908,7 @@ helpBindingToABC bin = go bin
 
 freshLetter:: State {count:: Int, env:: Map String String} String
 freshLetter = do
-    {count = count, env = env :: Map String String} <- get
+    {count: count, env: env :: Map String String} <- get
     put {count:count+1, env:env}
     return $ fromCharList $ newTypVar count
 

--- a/src/Web.purs
+++ b/src/Web.purs
@@ -611,6 +611,6 @@ indexBinding (NTupleLit bs) = do
 
 fresh ::State {count:: Int} Int
 fresh = do
-  {count = count} <- get
+  {count: count} <- get
   put {count:count+1}
   return count

--- a/src/Web.purs
+++ b/src/Web.purs
@@ -5,15 +5,15 @@ module Web
   , makeDiv
   ) where
 
-import Prelude (class Show, class Monad, Unit, return, (+), bind, ($), (++), (==), (/=), show, (>>=), flip, (<<<), (<$>), (&&), (>), void, unit, id, (-))
+import Prelude (class Show, class Monad, Unit, (+), bind, ($), (==), (/=), show, (<>), (>>=), flip, pure, (<<<), (<$>), (&&), (>), void, unit, id, (-))
 import Data.Foldable (all)
 import Data.Traversable (for)
 import Data.String (joinWith)
-import Data.List (List(Nil, Cons), singleton, fromList, toList, length, zip, (..), zipWithA)
+import Data.List (List(Nil, Cons), singleton, fromFoldable, toUnfoldable, length, zip, (..), zipWithA)
 import Data.Foreign (unsafeFromForeign, isUndefined)
-import Data.Maybe (Maybe(..), isJust)
-import Data.Maybe.Unsafe (fromJust)
+import Data.Maybe (Maybe(..), isJust, fromJust)
 import Data.Tuple (Tuple(..), fst, snd)
+import Data.Array as Array
 
 import Control.Apply ((*>))
 import Control.Bind ((=<<), (>=>))
@@ -35,8 +35,8 @@ getPath :: forall eff. J.JQuery -> Eff (dom :: DOM | eff) (Maybe Path)
 getPath j = do
   fpath <- J.getProp pathPropName j
   if isUndefined fpath
-    then return Nothing
-    else return $ Just $ unsafeFromForeign fpath
+    then pure Nothing
+    else pure $ Just $ unsafeFromForeign fpath
 
 exprToJQuery:: forall eff. Output -> Eff (dom :: DOM | eff) J.JQuery
 exprToJQuery output = go (output.expr)
@@ -56,7 +56,7 @@ exprToJQuery output = go (output.expr)
           jExpr <- exprToJQuery' output
           J.addClass "expr" jExpr
           J.append jExpr jtypExp
-          return jtypExp
+          pure jtypExp
 
 -- TODO rename to fit new Type
 exprToJQuery' :: forall eff. Output -> Eff (dom :: DOM | eff) J.JQuery
@@ -69,7 +69,7 @@ exprToJQuery' output = go id output
           jExpr <- children ".expr" jObj
           isNotEmpty <- J.hasClass "expr" jExpr
           if isNotEmpty then f jExpr else f jObj
-          return jObj
+          pure jObj
           )
     =<<
     case o of
@@ -93,7 +93,7 @@ exprToJQuery' output = go id output
       jop <- makeDiv (pPrintOp op) (singleton "op") >>= addTypetoDiv opt >>= addIdtoDiv opi
       j <- go (p <<< Snd) {expr:e, typ:tt, idTree: i}
       section jop j t i'
-    {expr:PrefixOp op, typ:TPrefixOp t, idTree: (IPrefixOp i)} -> makeDiv ("(" ++ pPrintOp op ++ ")") (toList ["prefix", "op"]) >>= addTypetoDiv t >>= addIdtoDiv i
+    {expr:PrefixOp op, typ:TPrefixOp t, idTree: (IPrefixOp i)} -> makeDiv ("(" <> pPrintOp op <> ")") (toUnfoldable ["prefix", "op"]) >>= addTypetoDiv t >>= addIdtoDiv i
     {expr:IfExpr cond thenExpr elseExpr, typ:TIfExpr tt1 tt2  tt3 t,idTree:IIfExpr i1 i2 i3 i} -> do
       jc <- go (p <<< Fst) {expr:cond, typ:tt1, idTree: i1}
       jt <- go (p <<< Snd) {expr:thenExpr, typ:tt2, idTree: i2}
@@ -101,26 +101,26 @@ exprToJQuery' output = go id output
       ifexpr jc jt je t i
 
     {expr:(ArithmSeq start step end), typ:(TArithmSeq tstart tstep tend t), idTree:(IArithmSeq istart istep iend i)} -> do
-      jStart <- go (p <<< Fst)  {expr:start, typ:tstart, idTree:istart} 
+      jStart <- go (p <<< Fst)  {expr:start, typ:tstart, idTree:istart}
       case (isJust step) && (isJust tstep) && (isJust istep) of
         true  -> case (isJust end) && (isJust tend) && (isJust iend) of
           true  -> do
             jStep <- go (p <<< Snd) {expr:(fromJust step), typ:(fromJust tstep), idTree:(fromJust istep)}
             jEnd  <- go (p <<< Thrd) {expr:(fromJust end), typ:(fromJust tend), idTree:(fromJust iend)}
-            arithmeticSequence jStart (Just jStep) (Just jEnd) t i 
+            arithmeticSequence jStart (Just jStep) (Just jEnd) t i
           false -> do
             jStep <- go (p <<< Snd) {expr:(fromJust step), typ:(fromJust tstep), idTree:(fromJust istep)}
-            arithmeticSequence jStart (Just jStep) Nothing t i   
+            arithmeticSequence jStart (Just jStep) Nothing t i
         false -> case (isJust end) && (isJust tend) && (isJust iend) of
           true  -> do
             jEnd  <- go (p <<< Thrd) {expr:(fromJust end), typ:(fromJust tend), idTree:(fromJust iend)}
-            arithmeticSequence jStart Nothing (Just jEnd) t i 
+            arithmeticSequence jStart Nothing (Just jEnd) t i
           false -> do
             arithmeticSequence jStart Nothing Nothing t i
 
     {expr:(ListComp expr quals), typ:(TListComp texpr tquals t), idTree:(IListComp iexpr iquals i)} -> do
-      jExpr  <- go (p <<< Fst) {expr:expr, typ:texpr, idTree:iexpr} 
-      jQuals <- zipWithA (\i (Tuple i' (Tuple e t)) -> qualifier (p <<< Nth i) e t i') 
+      jExpr  <- go (p <<< Fst) {expr:expr, typ:texpr, idTree:iexpr}
+      jQuals <- zipWithA (\i (Tuple i' (Tuple e t)) -> qualifier (p <<< Nth i) e t i')
         (0 .. (length quals - 1)) (zip iquals (zip quals tquals))
       listComp jExpr jQuals t i
 
@@ -158,13 +158,13 @@ exprToJQuery' output = go id output
       binding (Tuple ib (Tuple b tb)) >>= flip J.append result
       makeDiv "<-" Nil >>= flip J.append result
       go p {expr:e, typ:te, idTree:ie} >>= flip J.append result
-      return result      
+      pure result
   qualifier p (Let b e) (TLet tb te t) (TLet ib ie i) = do
       result <- makeDiv "let" Nil >>= addTypetoDiv t >>= addIdtoDiv i
       binding (Tuple ib (Tuple b tb)) >>= flip J.append result
       makeDiv "=" Nil >>= flip J.append result
-      go p {expr:e, typ:te, idTree:ie} >>= flip J.append result 
-      return result 
+      go p {expr:e, typ:te, idTree:ie} >>= flip J.append result
+      pure result
   qualifier p (Guard e) (TGuard te t) (TGuard ie i) = go p {expr:e, typ:te, idTree:ie}
   qualifier _ _ _ _ = makeDiv "You found a Bug in Web.exprToJquery'.qualifier" Nil
 
@@ -172,17 +172,17 @@ checkLength :: forall a b c. List a -> List b -> List c -> Boolean
 checkLength a b c = length a /= 0 && length a == length b && length a == length c && length b == length c
 
 atom :: forall eff. Atom -> Type -> Int ->  Eff (dom :: DOM | eff) J.JQuery
-atom (AInt n) t  i   = makeDiv (show n) (toList ["atom", "num"]) >>= addTypetoDiv t >>= addIdtoDiv i
-atom (Bool true) t i = makeDiv "True"  (toList ["atom", "bool"]) >>= addTypetoDiv t >>= addIdtoDiv i
-atom (Bool false) t i= makeDiv "False" (toList ["atom", "bool"]) >>= addTypetoDiv t >>= addIdtoDiv i
-atom (Char c) t  i  = (makeDiv ("'" ++ c ++ "'") (toList ["atom", "char"])) >>= addTypetoDiv t >>= addIdtoDiv i
+atom (AInt n) t  i   = makeDiv (show n) (toUnfoldable ["atom", "num"]) >>= addTypetoDiv t >>= addIdtoDiv i
+atom (Bool true) t i = makeDiv "True"  (toUnfoldable ["atom", "bool"]) >>= addTypetoDiv t >>= addIdtoDiv i
+atom (Bool false) t i= makeDiv "False" (toUnfoldable ["atom", "bool"]) >>= addTypetoDiv t >>= addIdtoDiv i
+atom (Char c) t  i  = (makeDiv ("'" <> c <> "'") (toUnfoldable ["atom", "char"])) >>= addTypetoDiv t >>= addIdtoDiv i
 atom (Name name) t i = do
  jtypExp <- makeDiv "" (singleton "atom name typExpContainer")
  jExpand <- buildExpandDiv t
  J.append jExpand jtypExp
- jName <- makeDiv name (toList ["atom", "name", "expr"]) >>= addTypetoDiv t >>= addIdtoDiv i
+ jName <- makeDiv name (toUnfoldable ["atom", "name", "expr"]) >>= addTypetoDiv t >>= addIdtoDiv i
  J.append jName jtypExp
- return jtypExp
+ pure jtypExp
 
 binding :: forall eff. Tuple IBinding (Tuple Binding TypeBinding) -> Eff (dom :: DOM | eff) J.JQuery
 binding b = case b of
@@ -206,7 +206,7 @@ binding b = case b of
     let b = (zip is (zip bs tbs))
     interleaveM_ (binding >=> flip J.append jTuple) (makeDiv "," (singleton "comma") >>= flip J.append jTuple) b
     makeDiv ")" (singleton "brace") >>= flip J.append jTuple
-    return jTuple
+    pure jTuple
 
   _ -> makeDiv ("congrats you found a bug in Web.binding") Nil
   where
@@ -232,7 +232,7 @@ lambda jBinds jBody t i = do
   close <- makeDiv ")" (singleton "brace")
   J.append close jLam
   J.append jLam jtypExp
-  return jtypExp
+  pure jtypExp
 
 binary :: forall eff. Op -> Type -> Int -> Type -> Int -> J.JQuery -> J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
 binary op opt opi t i j1 j2 = do
@@ -246,7 +246,7 @@ binary op opt opi t i j1 j2 = do
   J.append jExpand jtypExp
   J.addClass "expr" dBin
   J.append dBin jtypExp
-  return jtypExp
+  pure jtypExp
 
 unary:: forall eff. J.JQuery -> J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
 unary jop jexpr t i = do
@@ -257,7 +257,7 @@ unary jop jexpr t i = do
   J.append jop jUnary
   J.append jexpr jUnary
   J.append jUnary jtypExp
-  return jtypExp
+  pure jtypExp
 
 section :: forall eff. J.JQuery -> J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
 section j1 j2 t i = do
@@ -272,7 +272,7 @@ section j1 j2 t i = do
   close <- makeDiv ")" (singleton "brace")
   J.append close jSect
   J.append jSect jtypExp
-  return jtypExp
+  pure jtypExp
 
 ifexpr :: forall eff. J.JQuery -> J.JQuery -> J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
 ifexpr cond thenExpr elseExpr t i = do
@@ -287,7 +287,7 @@ ifexpr cond thenExpr elseExpr t i = do
   makeDiv "else" (singleton "keyword") >>= flip J.append dIf
   J.append elseExpr dIf
   J.append dIf jtypExp
-  return jtypExp
+  pure jtypExp
 
 arithmeticSequence :: forall eff. J.JQuery -> Maybe J.JQuery -> Maybe J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
 arithmeticSequence start mstep mend t i = do
@@ -302,16 +302,16 @@ arithmeticSequence start mstep mend t i = do
   maybeEnd das mend
   makeDiv "]" (singleton "brace") >>= flip J.append das
   J.append das jtypExp
-  return jtypExp  
+  pure jtypExp
   where
     maybeStep :: J.JQuery -> Maybe J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
-    maybeStep jquery Nothing = return jquery
+    maybeStep jquery Nothing = pure jquery
     maybeStep jquery (Just step) = do
-      makeDiv "," (singleton "comma") >>= flip J.append jquery 
+      makeDiv "," (singleton "comma") >>= flip J.append jquery
       J.append step jquery
 
     maybeEnd :: J.JQuery -> Maybe J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
-    maybeEnd jquery Nothing = return jquery
+    maybeEnd jquery Nothing = pure jquery
     maybeEnd jquery (Just end) = J.append end jquery
 
 listComp :: forall eff. J.JQuery -> List J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
@@ -322,11 +322,11 @@ listComp jExpr jQuals t i = do
   das <- makeDiv "" (singleton "list expr") >>= addTypetoDiv t >>= addIdtoDiv i
   makeDiv "[" (singleton "brace") >>= flip J.append das
   J.append jExpr das
-  makeDiv "|" (singleton "comma") >>= flip J.append das    
+  makeDiv "|" (singleton "comma") >>= flip J.append das
   interleaveM_ (flip J.append das) (makeDiv "," (singleton "comma") >>= flip J.append das) jQuals
   makeDiv "]" (singleton "brace") >>= flip J.append das
   J.append das jtypExp
-  return jtypExp  
+  pure jtypExp
 
 --TODO: create css entry for "let typExpContainer" and "let expr"
 letExpr :: forall eff. List J.JQuery -> J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
@@ -342,7 +342,7 @@ letExpr jBinds jExpr t i = do
   makeDiv "in" (singleton "keyword") >>= flip J.append dlet
   J.append jExpr dlet
   J.append dlet jtypExp
-  return jtypExp
+  pure jtypExp
 
 letBinding :: forall eff. J.JQuery -> J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
 letBinding jBind jExpr = do
@@ -352,12 +352,12 @@ letBinding jBind jExpr = do
   makeDiv "=" Nil >>= flip J.append dlet
   J.append jExpr dlet
   J.append dlet jtypExp
-  return jtypExp
+  pure jtypExp
 
 interleaveM_ :: forall a b m. (Monad m) => (a -> m b) -> m b -> List a -> m Unit
 interleaveM_ f sep = go
   where
-  go Nil     = return unit
+  go Nil     = pure unit
   go (Cons x Nil)    = void $ f x
   go (Cons x xs) = f x *> sep *> go xs
 
@@ -373,7 +373,7 @@ tuple js t i = do
   close <- makeDiv ")" (singleton "brace")
   J.append close dtuple
   J.append dtuple jtypExp
-  return jtypExp
+  pure jtypExp
 
 list :: forall eff. List J.JQuery -> Type -> Int -> Eff (dom :: DOM | eff) J.JQuery
 list js t   i  = do
@@ -387,7 +387,7 @@ list js t   i  = do
   close <- makeDiv "]" (singleton "brace")
   J.append close dls
   J.append dls jtypExp
-  return jtypExp
+  pure jtypExp
 
 isString :: List Expr -> Boolean
 isString es = length es > 0 && all isChar es
@@ -400,12 +400,12 @@ string str t i = do
   jtypExp <- makeDiv "" (singleton "list string typExpContainer")
   jExpand <- buildExpandDiv t
   J.append jExpand jtypExp
-  jString <- makeDiv ("\"" ++ str ++ "\"") (toList ["list", "string", "expr"]) >>= addTypetoDiv t >>= addIdtoDiv i
+  jString <- makeDiv ("\"" <> str <> "\"") (toUnfoldable ["list", "string", "expr"]) >>= addTypetoDiv t >>= addIdtoDiv i
   J.append jString  jtypExp
 
 toStr :: List Expr -> Maybe String
 toStr Nil = Nothing
-toStr ls  = (joinWith "" <<< fromList) <$> for ls extract
+toStr ls  = (joinWith "" <<< Array.fromFoldable) <$> for ls extract
   where
    extract:: Expr -> Maybe String
    extract (Atom (Char s)) = Just s
@@ -431,7 +431,7 @@ app jFunc jArgs tFunc t i = do
   J.append jFunc dApp
   for jArgs (flip J.append dApp)
   J.append dApp jtypExp
-  return jtypExp
+  pure jtypExp
 
 type Class = String
 
@@ -440,7 +440,7 @@ makeDiv text classes = do
   d <- J.create "<div></div>"
   J.setText text d
   for classes (flip J.addClass d)
-  return d
+  pure d
 
 emptyJQuery:: forall eff . Eff (dom :: DOM | eff) J.JQuery
 emptyJQuery = J.create ""
@@ -460,23 +460,23 @@ addTypetoDiv typ d = do
 
 addIdtoDiv:: forall eff a. (Show a) => a -> J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
 addIdtoDiv id d = do
-    J.setAttr "id" ("expr"++(show id)) d
+    J.setAttr "id" ("expr"<>(show id)) d
 
 addTypIdtoDiv:: forall eff a. (Show a) => a -> J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
 addTypIdtoDiv id d = do
-    J.setAttr "id" ("typ"++(show id)) d
+    J.setAttr "id" ("typ"<>(show id)) d
 
 addResultIdtoDiv:: forall eff a. (Show a) => a -> J.JQuery -> Eff (dom :: DOM | eff) J.JQuery
 addResultIdtoDiv id d = do
-    J.setAttr "id" ("typ" ++ (show id) ++ "result") d
+    J.setAttr "id" ("typ" <> (show id) <> "result") d
 
 
 buildExpandDiv:: forall eff. Type  -> Eff (dom :: DOM | eff) J.JQuery
 buildExpandDiv t  = do
-  typC <- makeDiv ("::" ++ prettyPrintType t) $ Cons "type" Nil
+  typC <- makeDiv ("::" <> prettyPrintType t) $ Cons "type" Nil
   case t of
     (TypeError _) -> J.css {color: "red"} typC
-    _ -> return typC
+    _ -> pure typC
   expandC <- makeDiv "" $ Cons "expand"  Nil
   jArrow <- makeDiv "▼" $ Cons "type-arr" Nil
   J.append jArrow expandC
@@ -496,121 +496,121 @@ buildExpandDiv t  = do
   J.setAttr "title" "show Type" expandC
   J.setAttr "title" "hide Type" typC
   J.css {display: "inline-block"} typC
-  return expandC
+  pure expandC
 
 idExpr:: Expr -> IndexTree
 idExpr e = fst $ runState (indexExpr e) {count:0}
 
 mapM' :: forall a b m. (Monad m) => (a -> m b) -> Maybe a -> m (Maybe b)
-mapM' f Nothing  = return Nothing
+mapM' f Nothing  = pure Nothing
 mapM' f (Just x) = Just <$> (f x)
 
 indexExpr:: Expr -> State {count:: Int} IndexTree
 indexExpr (Atom _) = do
                   i <- fresh
-                  return $ IAtom i
+                  pure $ IAtom i
 indexExpr (List es) = do
                   is <- mapM indexExpr es
                   i <- fresh
-                  return $ IListTree is i
+                  pure $ IListTree is i
 indexExpr (NTuple es) = do
                   is <- mapM indexExpr es
                   i <- fresh
-                  return $ INTuple is i
+                  pure $ INTuple is i
 indexExpr (Binary _ e1 e2) = do
                   i1 <- indexExpr e1
                   i2 <- indexExpr e2
                   i <- fresh
                   i' <- fresh
-                  return $ (IBinary i' i1 i2 i)
+                  pure $ (IBinary i' i1 i2 i)
 indexExpr (Unary _ e) = do
                   i <- indexExpr e
                   i' <- fresh
                   i'' <- fresh
-                  return $ IUnary i'' i i'
+                  pure $ IUnary i'' i i'
 indexExpr (SectL e _) = do
                   i <- indexExpr e
                   i' <- fresh
                   i'' <- fresh
-                  return $ ISectL i i'' i'
+                  pure $ ISectL i i'' i'
 indexExpr (SectR _ e) = do
                   i <- indexExpr e
                   i' <- fresh
                   i'' <- fresh
-                  return $ ISectR i'' i i'
+                  pure $ ISectR i'' i i'
 indexExpr (PrefixOp _) = do
                   i <- fresh
-                  return $ IPrefixOp i
+                  pure $ IPrefixOp i
 indexExpr (IfExpr e1 e2 e3) = do
                   i1 <- indexExpr e1
                   i2 <- indexExpr e2
                   i3 <- indexExpr e3
                   i <- fresh
-                  return $ IIfExpr i1 i2 i3 i
+                  pure $ IIfExpr i1 i2 i3 i
 indexExpr (ArithmSeq e1 e2 e3) = do
                   i1 <- indexExpr e1
                   i2 <- mapM' indexExpr e2
                   i3 <- mapM' indexExpr e3
                   i <- fresh
-                  return $ IArithmSeq i1 i2 i3 i                  
+                  pure $ IArithmSeq i1 i2 i3 i
 indexExpr (LetExpr bin e) = do
                   ib <- mapM (indexBinding <<< fst) bin
                   ie <- mapM (indexExpr <<< snd) bin
                   i2 <- indexExpr e
                   i  <- fresh
-                  return $ ILetExpr (zip ib ie) i2 i
+                  pure $ ILetExpr (zip ib ie) i2 i
 indexExpr (Lambda bs e) = do
                  ibs <- mapM indexBinding bs
                  i <- indexExpr e
                  i' <- fresh
-                 return $ ILambda ibs i i'
+                 pure $ ILambda ibs i i'
 indexExpr (App e es) = do
                 e1 <- indexExpr e
                 is <- mapM indexExpr es
                 i <- fresh
-                return $ IApp e1 is i
+                pure $ IApp e1 is i
 indexExpr (ListComp e qs) = do
                 e1 <- indexExpr e
                 is <- mapM indexQual qs
                 i <- fresh
-                return $ IListComp e1 is i
+                pure $ IListComp e1 is i
 
 indexQual :: ExprQual -> State {count :: Int} IndexQual
 indexQual (Gen b e) = do
   b' <- indexBinding b
   e' <- indexExpr e
   i  <- fresh
-  return $ TGen b' e' i
+  pure $ TGen b' e' i
 indexQual (Let b e) = do
   b' <- indexBinding b
   e' <- indexExpr e
   i  <- fresh
-  return $ TLet b' e' i
+  pure $ TLet b' e' i
 indexQual (Guard e) = do
   e' <- indexExpr e
-  i  <- fresh 
-  return $ TGuard e' i
+  i  <- fresh
+  pure $ TGuard e' i
 
 indexBinding:: Binding -> State {count :: Int} IBinding
 indexBinding (Lit _) = do
                     i <- fresh
-                    return $ ILit i
+                    pure $ ILit i
 indexBinding (ConsLit b1 b2 ) = do
                       i1 <- indexBinding b1
                       i2 <- indexBinding b2
                       i <- fresh
-                      return $ IConsLit i1 i2 i
+                      pure $ IConsLit i1 i2 i
 indexBinding (ListLit bs) = do
                         is <- mapM indexBinding bs
                         i <- fresh
-                        return $ IListLit is i
+                        pure $ IListLit is i
 indexBinding (NTupleLit bs) = do
                       is <- mapM indexBinding bs
                       i <- fresh
-                      return $ INTupleLit is i
+                      pure $ INTupleLit is i
 
 fresh ::State {count:: Int} Int
 fresh = do
-  {count: count} <- get
+  {count: count} :: {count :: Int} <- get
   put {count:count+1}
-  return count
+  pure count

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,6 +1,6 @@
 module Test.Main where
 
-import Prelude (Unit, show, (++), ($), bind, (==), (+))
+import Prelude (Unit, show, (<>), ($), bind, (==), (+))
 import Data.List (length)
 import Data.Traversable (for)
 
@@ -18,12 +18,12 @@ main :: forall eff. Eff (console :: CONSOLE, process :: PROCESS | eff) Unit
 main = do
   log $ "Running parser tests..."
   let parserLog = execWriter Parser.runTests
-  log $ "  ...found " ++ show (length parserLog) ++ " errors"
+  log $ "  ...found " <> show (length parserLog) <> " errors"
   for parserLog log
 
   log $ "Running evaluator tests..."
   let evaluatorLog = execWriter Evaluator.runTests
-  log $ "  ...found " ++ show (length evaluatorLog) ++ " errors"
+  log $ "  ...found " <> show (length evaluatorLog) <> " errors"
   for evaluatorLog log
 
   TypeChecker.runTests
@@ -34,5 +34,5 @@ main = do
       log $ "All tests succesfull"
       exit 0
     else do
-      log $ "Found " ++ show errorCount ++ " errors!"
+      log $ "Found " <> show errorCount <> " errors!"
       exit 1

--- a/test/TestEvaluator.purs
+++ b/test/TestEvaluator.purs
@@ -1,6 +1,6 @@
 module Test.Evaluator where
 
-import Prelude (Unit, bind, (++), ($), show, unit, return, (==), (<<<), (+), negate, (*))
+import Prelude (Unit, bind, (<>), ($), show, unit, pure, (==), (<<<), (+), negate, (*))
 import Data.Either (Either(..))
 import Data.Tuple (Tuple(..))
 import Data.StrMap as M
@@ -21,10 +21,10 @@ eval1test name input expected = case (Tuple (runParserIndent expression input) (
     case runEvalM (eval1 M.empty inExp) of
       (Right eval1Exp) -> 
         if eval1Exp == expExp
-          then return unit -- log $ "Eval success (" ++ name ++ ")"
-          else tell' $ "Eval fail (" ++ name ++ "): " ++ show eval1Exp ++ " should be " ++ show expExp
-      (Left err) -> tell' $ "Eval fail (" ++ name ++ "): " ++ show err ++ ")"
-  _ -> tell' $ "Parse fail (" ++ name ++ ")"
+          then pure unit -- log $ "Eval success (" ++ name ++ ")"
+          else tell' $ "Eval fail (" <> name <> "): " <> show eval1Exp <> " should be " <> show expExp
+      (Left err) -> tell' $ "Eval fail (" <> name <> "): " <> show err <> ")"
+  _ -> tell' $ "Parse fail (" <> name <> ")"
 
 eval1EnvTest :: String -> String -> String -> String -> Writer (List String) Unit
 eval1EnvTest name env input expected = case (Tuple (Tuple (runParserIndent expression input) (runParserIndent expression expected)) (runParserIndent definitions env)) of
@@ -32,19 +32,19 @@ eval1EnvTest name env input expected = case (Tuple (Tuple (runParserIndent expre
     case runEvalM (eval1 (defsToEnv defs) inExp) of
       (Right eval1Exp) -> 
         if eval1Exp == expExp
-          then return unit -- log $ "Eval success (" ++ name ++ ")"
-          else tell' $ "Eval fail (" ++ name ++ "): " ++ show eval1Exp ++ " should be " ++ show expExp
-      (Left err) -> tell' $ "Eval fail (" ++ name ++ "): " ++ show err ++ ")"
-  _ -> tell' $ "Parse fail (" ++ name ++ ")"
+          then pure unit -- log $ "Eval success (" <> name <> ")"
+          else tell' $ "Eval fail (" <> name <> "): " <> show eval1Exp <> " should be " <> show expExp
+      (Left err) -> tell' $ "Eval fail (" <> name <> "): " <> show err <> ")"
+  _ -> tell' $ "Parse fail (" <> name <> ")"
 
 evalEnvTest :: String -> String -> String -> String -> Writer (List String) Unit
 evalEnvTest name env input expected = case (Tuple (Tuple (runParserIndent expression input) (runParserIndent expression expected)) (runParserIndent definitions env)) of
   (Tuple (Tuple (Right inExp) (Right expExp)) (Right defs)) ->
     let evalExp = eval (defsToEnv defs) inExp in
       if evalExp == expExp
-        then return unit -- log $ "Eval success (" ++ name ++ ")"
-        else tell' $ "Eval fail (" ++ name ++ "): " ++ show evalExp ++ " should be " ++ show expExp
-  (Tuple (Tuple pi pe) pd) -> tell' $ "Parse fail (" ++ name ++ "): (input: " ++ show pi ++ ", expected: " ++ show pe ++ ", definitions: " ++ show pd ++ ")"
+        then pure unit -- log $ "Eval success (" ++ name ++ ")"
+        else tell' $ "Eval fail (" <> name <> "): " <> show evalExp <> " should be " <> show expExp
+  (Tuple (Tuple pi pe) pd) -> tell' $ "Parse fail (" <> name <> "): (input: " <> show pi <> ", expected: " <> show pe <> ", definitions: " <> show pd <> ")"
 
 runTests :: Writer (List String) Unit
 runTests = do
@@ -103,14 +103,14 @@ runTests = do
   evalEnvTest "prelude" prelude "sum (map (^2) [1,2,3,4])" "30"
 
   evalEnvTest "TAE2a"
-    ( prelude ++ "\n" ++
-      "pair (x:y:rs) = (x, y) : pair (y:rs)\n" ++
+    ( prelude <> "\n" <>
+      "pair (x:y:rs) = (x, y) : pair (y:rs)\n" <>
       "pair _        = []")
     "pair [1, 2, 3, 4]"
     "[(1, 2), (2, 3), (3, 4)]"
   evalEnvTest "TAE2b" prelude "foldr (\\a b -> a + b * 10) 0 [3, 2, 1]" "123"
   evalEnvTest "TAE2c"
-    (prelude ++ "\nsublist f t ls = drop f (take (t + f) ls)\n")
+    (prelude <> "\nsublist f t ls = drop f (take (t + f) ls)\n")
     "sublist 1 3 [0, 1, 2, 3, 4]"
     "[1, 2, 3]"
 
@@ -123,12 +123,12 @@ runTests = do
   evalEnvTest "TAE3g" prelude "foldl (\\(i, c) s -> (i + 1, c + length s)) (0, 0) [\"a\", \"bc\", \"defg\"]" "(3, 7)"
 
   evalEnvTest "TAT2a"
-    (prelude ++ "\nnth ls n = head (drop n ls)\n")
+    (prelude <> "\nnth ls n = head (drop n ls)\n")
     "nth [0, 1, 2, 3] 2"
     "2"
   evalEnvTest "TAT2b"
-    ( prelude ++ "\n" ++
-      "smallest (x:y:rs) = if x < y then smallest (x:rs) else smallest (y:rs)\n" ++
+    ( prelude <> "\n" <>
+      "smallest (x:y:rs) = if x < y then smallest (x:rs) else smallest (y:rs)\n" <>
       "smallest [x]      = x")
     "smallest [5, 3, 7]"
     "3"

--- a/test/TypeChecker.purs
+++ b/test/TypeChecker.purs
@@ -4,17 +4,20 @@ import AST (AD(TList, TTuple), Atom(AInt, Name, Char), Binding(Lit, ConsLit, Lis
 import TypeChecker (Subst, Infer, TypeEnv, Scheme(Forall), inferGroup, inferType, inferDef, prettyPrintType, emptyTyenv, runInfer, typeProgramn, eqScheme)
 import Parser (expression, definition, runParserIndent)
 
-import Prelude (Unit, bind, ($), show, (==), (++))
+import Prelude (Unit, bind, ($), show, (==), (<>))
 import Data.Either (Either(..))
-import Data.List (List(..), toList)
+import Data.List (List(..))
+import Data.Array (toUnfoldable) as Array
 import Data.Tuple (Tuple(..))
+import Test.Parser (parsedPrelude)
 
 import Text.Parsing.Parser (ParseError)
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
-import Control.Monad.State
+toList :: forall a. Array a -> List a
+toList = Array.toUnfoldable
 
 testInfer:: forall a  eff. String -> a -> (TypeEnv -> a -> Infer (Tuple Subst Type))
  -> Either TypeError Scheme -> Eff (console :: CONSOLE | eff ) Unit
@@ -30,11 +33,11 @@ testProgramm name defs exp expected
 test:: forall eff. String -> Either TypeError Scheme -> Either TypeError Scheme
  -> Eff (console :: CONSOLE | eff ) Unit
 test name expected actuall = if eqTypErrScheme expected actuall
-  then log $ "Typing success ("  ++ name ++ ")"
-  else log $ "\n \n Typing fail (" ++ name ++ ") :  expected result: \n"
-    ++ show expected ++ "\n actuall result: \n" ++ show actuall ++ "\n \n"
-     ++ "Pretty Print expected: \n" ++ prettyPrint expected
-      ++ "\n Pretty Print actuall: \n" ++ prettyPrint actuall ++ "\n \n"
+  then log $ "Typing success ("  <> name <> ")"
+  else log $ "\n \n Typing fail (" <> name <> ") :  expected result: \n"
+    <> show expected <> "\n actuall result: \n" <> show actuall <> "\n \n"
+     <> "Pretty Print expected: \n" <> prettyPrint expected
+      <> "\n Pretty Print actuall: \n" <> prettyPrint actuall <> "\n \n"
 
 eqTypErrScheme:: Either TypeError Scheme -> Either TypeError Scheme -> Boolean
 eqTypErrScheme (Left a) (Left a') = (a == a')
@@ -67,7 +70,7 @@ typeStr expS = case runParserIndent expression expS of
 
 typeStrPre:: String -> Either TypeError Scheme
 typeStrPre expS = case runParserIndent expression expS of
-  Right exp -> typeProgramn Test.Parser.parsedPrelude exp
+  Right exp -> typeProgramn parsedPrelude exp
   Left _ -> Left $ UnknownError "Parse Error"
 
 typeExp:: Expr -> Either TypeError Scheme
@@ -87,6 +90,7 @@ printTypeStr::forall eff. String -> Eff (console :: CONSOLE | eff ) Unit
 printTypeStr s = out $ prettyPrint $ typeStr s
 
 -- default 1
+d1 :: Either TypeError Scheme
 d1 = Right (Forall Nil $ tvar "a")
 
 runTests :: forall eff. Eff (console :: CONSOLE | eff) Unit
@@ -162,6 +166,6 @@ runTests = do
                                      Def "scanl" (Cons (Lit (Name "f")) (Cons (Lit (Name "b")) (Cons (ConsLit (Lit (Name "x")) (Lit (Name "xs"))) (Nil)))) (Binary Colon (Atom (Name "b")) (App (Atom (Name "scanl")) (Cons (Atom (Name "f")) (Cons (App (Atom (Name "f")) (Cons (Atom (Name "b")) (Cons (Atom (Name "x")) (Nil)))) (Cons (Atom (Name "xs")) (Nil))))))])
           inferGroup (Right (Forall (Cons ((TVar "t_39")) (Cons ((TVar "t_48")) (Nil))) (TypArr (TypArr (TypVar  (TVar "t_48")) (TypArr (TypVar  (TVar "t_39")) (TypVar  (TVar "t_48")))) (TypArr (TypVar  (TVar "t_48")) (TypArr (AD (TList (TypVar  (TVar "t_39")))) (AD (TList (TypVar  (TVar "t_48")))))))))
 
-  testProgramm "Prelude with exp" Test.Parser.parsedPrelude
+  testProgramm "Prelude with exp" parsedPrelude
     ((App (Atom (Name "sum")) (Cons (App (Atom (Name "map")) (Cons (SectR Power (Atom (AInt 2))) (Cons (List (Cons (Atom (AInt 1)) (Cons (Atom (AInt 2)) (Cons (Atom (AInt 3)) (Cons (Atom (AInt 4)) (Nil)))))) (Nil)))) (Nil))))
     (Right (Forall (Nil) (TypCon "Int")))


### PR DESCRIPTION
Note: This patch also includes all necessary changes in order to support PureScript 0.10.1.
Updating to PureScript 0.10.1 would require updating the dependencies as well.

Don't forget to update PureScript, Pulp and the dependencies:

```
npm install -g purescript@0.9.3
npm install -g pulp@9.0.1

rm -rf bower_components
bower cache clean
bower install
```
